### PR TITLE
Reporting - Update version

### DIFF
--- a/Reporting.s4ext
+++ b/Reporting.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl https://github.com/fedorov/Reporting.git
-scmrevision ad3b14d
+scmrevision c5eaae7
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files


### PR DESCRIPTION
Addresses Reporting issue 34 (propagation of label update to markup elements) and adds a standalone module for exporting label as a DICOM SEG object (single label), see issue 31
