### PR TITLE
BUG: DTIProcess tools where not installed at the correct location. Every...

### DIFF
--- a/DTIProcess.s4ext
+++ b/DTIProcess.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm svn
 scmurl https://www.nitrc.org/svn/dtiprocess/branches/Slicer4Extension
-scmrevision 111
+scmrevision 119
 svnusername slicerbot
 svnpassword slicer
 


### PR DESCRIPTION
...thing is now set up and compiled using the script in SEM

The tools should now install properly in ${CMAKE_INSTALL_PREFIX}/lib/Slicer-4.2/cli-modules/ upon the call of the installation command.
