### PR TITLE
Update DTIProcess extension

### DIFF
--- a/DTIProcess.s4ext
+++ b/DTIProcess.s4ext
@@ -1,0 +1,46 @@
+#
+# First token of each non-comment line is the keyword and the rest of the line
+# (including spaces) is the value.
+# - the value can be blank
+#
+
+# This is source code manager (i.e. svn)
+scm svn
+scmurl https://www.nitrc.org/svn/dtiprocess/branches/Slicer4Extension
+scmrevision 141
+svnusername slicerbot
+svnpassword slicer
+
+# list dependencies
+# - These should be names of other modules that have .s4ext files
+# - The dependencies will be built first
+depends     NA
+
+# Inner build directory (default is .)
+build_subdirectory DTIProcess-build
+
+# homepage
+homepage    http://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/DTIProcess
+
+# Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
+# For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)
+contributors Francois Budin (UNC)
+
+# Match category in the xml description of the module (where it shows up in Modules menu)
+category    Diffusion
+
+# url to icon (png, size 128x128 pixels)
+iconurl     http://www.nitrc.org/project/screenshot.php?group_id=312&screenshot_id=575
+
+# Give people an idea what to expect from this code
+#  - Is it just a test or something you stand beind?
+status      
+
+# One line stating what the module does
+description This extension provides the tool DTIProcess integrated in Slicer
+
+# Space separated list of urls
+screenshoturls http://www.slicer.org/slicerWiki/images/thumb/b/b8/DTIEstim-B0-crop.png/193px-DTIEstim-B0-crop.png http://www.slicer.org/slicerWiki/images/thumb/9/90/FiberTrack-fibers.png/138px-FiberTrack-fibers.png
+
+# 0 or 1: Define if the extension should be enabled after its installation.
+enabled 1


### PR DESCRIPTION
The extension has been entirely repackage to compile and package properly. The cmake flags are now given to the sub project through superbuild. The cmake\* files follow the same format as the one provided by Slicer and DTIPrep.
