### PR TITLE
Add DTIAtlasBuilder extension See issue #167

### DIFF
--- a/DTIAtlasBuilder.s4ext
+++ b/DTIAtlasBuilder.s4ext
@@ -1,0 +1,44 @@
+#
+# First token of each non-comment line is the keyword and the rest of the line
+# (including spaces) is the value.
+# - the value can be blank
+#
+
+# This is source code manager (i.e. svn)
+scm git
+scmurl git://github.com/adrienkaiser/DTIAtlasBuilder.git
+scmrevision c3db14d3f742b913978e4e1b0f0ae657a1ca0878
+
+# list dependencies
+# - These should be names of other modules that have .s4ext files
+# - The dependencies will be built first
+depends     NA
+
+# Inner build directory (default is .)
+build_subdirectory DTIAtlasBuilder-build
+
+# homepage
+homepage    http://www.nitrc.org/projects/dtiatlasbuilder
+
+# Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
+# For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)
+contributors Adrien Kaiser (UNC)
+
+# Match category in the xml description of the module (where it shows up in Modules menu)
+category    Diffusion
+
+# url to icon (png, size 128x128 pixels)
+iconurl     http://www.nitrc.org/project/screenshot.php?group_id=312&screenshot_id=575
+
+# Give people an idea what to expect from this code
+#  - Is it just a test or something you stand beind?
+status      Beta
+
+# One line stating what the module does
+description A tool to create a DTI Atlas Image from a set of DTI Images
+
+# Space separated list of urls
+screenshoturls http://www.slicer.org/slicerWiki/images/thumb/b/b8/DTIEstim-B0-crop.png/193px-DTIEstim-B0-crop.png http://www.slicer.org/slicerWiki/images/thumb/9/90/FiberTrack-fibers.png/138px-FiberTrack-fibers.png
+
+# 0 or 1: Define if the extension should be enabled after its installation.
+enabled 1


### PR DESCRIPTION
DTIAtlasBuilder is a tool to create an DTI atlas image from several DTI images : https://www.nitrc.org/projects/dtiatlasbuilder

Your can find the source code here : https://github.com/NIRALUser/DTIAtlasBuilder
A tutorial is available on NITRC : https://www.nitrc.org/docman/view.php/636/1189/DTIAtlasBuilder_Tutorial.pdf

The tool is a GUI where the user can add his DTI images, and set several options. Then the program will write a python script and run it to call external tools to process the data and create the Atlas.
