### PR TITLE
BUG: On Mac, create links to the lib and Frameworks folders so the executables find the libs from Slicer

### DIFF
--- a/DTIAtlasBuilder.s4ext
+++ b/DTIAtlasBuilder.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl git://github.com/NIRALUser/DTIAtlasBuilder.git
-scmrevision cb8f0f7cb30bd80995d59885b9ba17b98cec6cc5
+scmrevision dd213c908bbef18dbfc4d7fa07ae5ced4258b26b
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files


### PR DESCRIPTION
Compare View from last revision to new revision:
http://github.com/NIRALUser/DTIAtlasBuilder/compare/cb8f0f7...dd213c9
