### PR TITLE
BUG: Packaging on Mac had problems. Software compiled with dynamic libra...

### DIFF
--- a/DTIPrep.s4ext
+++ b/DTIPrep.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm svn
 scmurl https://www.nitrc.org/svn/dtiprep/trunk
-scmrevision 232
+scmrevision 233
 svnusername slicerbot
 svnpassword slicer
 


### PR DESCRIPTION
...ries were not installed properly. The libraries were installed in the wrong directory. For simplification purposes we removed those software that were not necessary from the package

Differences with previous commit:
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dtiprep&revision=233
