### PR TITLE
BUG: Packaging was badly done on linux and links to library and Framewor...

### DIFF
--- a/DTIProcess.s4ext
+++ b/DTIProcess.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm svn
 scmurl https://www.nitrc.org/svn/dtiprocess/branches/Slicer4Extension
-scmrevision 160
+scmrevision 161
 svnusername slicerbot
 svnpassword slicer
 


### PR DESCRIPTION
...ks directory were missing

Diff with previous commit:
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dtiprocess&revision=161
