### PR TITLE
BUG: Links for libraries for Mac install re-created on mac

### DIFF
--- a/DTIAtlasFiberAnalyzer.s4ext
+++ b/DTIAtlasFiberAnalyzer.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm svn
 scmurl https://www.nitrc.org/svn/dti_tract_stat/trunk/
-scmrevision 103
+scmrevision 105
 svnusername slicerbot
 svnpassword slicer
 


### PR DESCRIPTION
Diff with previous commit:
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dti_tract_stat&revision=105
