### PR TITLE
ENH: DTIProcess doesn't recompile ITKv4 anymore since it is included in ...

### DIFF
--- a/DTIProcess.s4ext
+++ b/DTIProcess.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm svn
 scmurl https://www.nitrc.org/svn/dtiprocess/branches/Slicer4Extension
-scmrevision 161
+scmrevision 173
 svnusername slicerbot
 svnpassword slicer
 


### PR DESCRIPTION
...Slicer4. Applications are now compiled as dynamic libraries. This saves a lot of compilation time and disk space. The package is also much smaller.
