### PR TITLE
COMP: Apply Iowa superbuild contributions and avoid windows/macos build errors

### DIFF
--- a/DTIAtlasBuilder.s4ext
+++ b/DTIAtlasBuilder.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl git://github.com/NIRALUser/DTIAtlasBuilder.git
-scmrevision 8f82f51b1851fa5d56a014bdee4b6ddcf2a9a23f
+scmrevision 5c2ca59634ace2a325c73a6f30b2a7ba8d7ec80a
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files


### PR DESCRIPTION
http://github.com/NIRALUser/DTIAtlasBuilder/compare/8f82f51b...5c2ca59

This update should remove build issues on Windows/MacOS, as only the CLI modules that compile on these platforms will be built.

The Iowa build contributions are mainly improvements to avoid specific build issues.
