### PR TITLE
Reporting - fix label editing update

### DIFF
--- a/Reporting.s4ext
+++ b/Reporting.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl https://github.com/fedorov/Reporting.git
-scmrevision 70f6144
+scmrevision 9b6ca6f
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files


### PR DESCRIPTION
This undoes previous messy fixes and should remove the key issue: deep copy is
needed to disconnect from the pipeline.

https://github.org/fedorov/Reporting/compare/9b6ca6f...70f6144
