### PR TITLE
Adding PerkTutor extension. Removing PerkNav extension.

### DIFF
--- a/PerkTutor.s4ext
+++ b/PerkTutor.s4ext
@@ -5,9 +5,9 @@
 #
 
 # This is source code manager (i.e. svn)
-scm svn
-scmurl http://subversion.assembla.com/svn/slicerigt/trunk/Slicer4
-scmrevision 174
+scm git
+scmurl https://github.com/PerkTutor/PerkTutor.git
+scmrevision 8d174a7
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files
@@ -15,30 +15,30 @@ scmrevision 174
 depends     NA
 
 # Inner build directory (default is .)
-build_subdirectory .
+build_subdirectory inner-build
 
 # homepage
-homepage    https://www.assembla.com/spaces/slicerigt
+homepage    https://github.com/PerkTutor/PerkTutor/wiki
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
 # For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)
-contributors Tamas Ungi (Queen's University)
+contributors Tamas Ungi, Matthew S. Holden (Queen's University)
 
 # Match category in the xml description of the module (where it shows up in Modules menu)
 category    IGT
 
 # url to icon (png, size 128x128 pixels)
-iconurl     http://wiki.slicer.org/slicerWiki/images/2/2f/PerkNavLogo.png
+iconurl     http://www.slicer.org/slicerWiki/images/2/21/PerkTutorLogo.png
 
 # Give people an idea what to expect from this code
 #  - Is it just a test or something you stand beind?
 status      
 
 # One line stating what the module does
-description Extensions for image-guided interventions
+description This extension holds modules for training of needle interventions and analysis of operator performance.
 
 # Space separated list of urls
-screenshoturls http://wiki.slicer.org/slicerWiki/images/b/bf/PerkNavScreenshot.png
+screenshoturls http://www.slicer.org/slicerWiki/images/2/28/PerkTutorScreenshot.png
 
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 1


### PR DESCRIPTION
PerkNav modules have been all moved to SlicerIGT extension or PerkTutor extension.
