### PR TITLE
ChangeTrackerPy - adding self test

### DIFF
--- a/ChangeTracker.s4ext
+++ b/ChangeTracker.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl https://github.com/fedorov/ChangeTrackerPy.git
-scmrevision a850b00
+scmrevision 42c14f1
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files


### PR DESCRIPTION
https://github.com/fedorov/ChangeTrackerPy/compare/a850b00...42c14f1

RSNA2012Quant test in Slicer trunk should be updated to exclude ChangeTracker
part, as it is no longer built as part of the app
