### PR TITLE
ENH: VTK is not built anymore within this extension and FiberViewerLight...

### DIFF
--- a/FiberViewerLight.s4ext
+++ b/FiberViewerLight.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm svn
 scmurl https://www.nitrc.org/svn/fvlight/trunk
-scmrevision 53
+scmrevision 54
 svnusername slicerbot
 svnpassword slicer
 


### PR DESCRIPTION
... is built as a dynamic library to enable the usage of the extension on Mac
