### PR TITLE
Update VMTKSlicerExtension extension

### DIFF
--- a/VMTKSlicerExtension.s4ext
+++ b/VMTKSlicerExtension.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl git://github.com/haehn/VMTKSlicerExtension.git
-scmrevision 65eac28
+scmrevision f403332
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files


### PR DESCRIPTION
A space after -F seems to break the build:

http://slicer.cdash.org/viewBuildError.php?buildid=76281

Indeed, man ld says:

 -Fdir       Add dir to the list of directories in which to search for
             frameworks.  Directories specified with -F are searched in
             the order they appear on the command line and before the
             default search path. In Xcode4 and later, there can be a
             space between the -F and directory.
So we need to remove the space for backward compatibility.
