### PR TITLE
ChangeTracker - fixing CLI packaging

### DIFF
--- a/ChangeTracker.s4ext
+++ b/ChangeTracker.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl https://github.com/fedorov/ChangeTrackerPy.git
-scmrevision 42c14f1
+scmrevision 39d198b
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files


### PR DESCRIPTION
Attempt to fix packaging of CLI that is not being loaded correctly due to a
missing shared library path.

https://github.com/fedorov/ChangeTrackerPy/compare/42c14f1...39d198b
