### PR TITLE
ChangeTracker - update cmake macro

### DIFF
--- a/ChangeTracker.s4ext
+++ b/ChangeTracker.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl https://github.com/fedorov/ChangeTrackerPy.git
-scmrevision 39d198b
+scmrevision 47aca45
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files


### PR DESCRIPTION
Use the new macro instead of the deprecated one

https://github.com/fedorov/ChangeTrackerPy/compare/39d198b...47aca45
