### PR TITLE
ENH: Addition of a launcher to start DTIPrep from Slicer when DTIPrep is...

### DIFF
--- a/DTIPrep.s4ext
+++ b/DTIPrep.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm svn
 scmurl https://www.nitrc.org/svn/dtiprep/trunk
-scmrevision 233
+scmrevision 240
 svnusername slicerbot
 svnpassword slicer
 


### PR DESCRIPTION
... build as an extension. The main DTIPrep is not detected correctly as a CLI module by Sl

icer for an unknown reason.

Diff: http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dtiprep&revision=240
