### PR TITLE
Update ErodeDilateLabel extension to fix build_subdirectory field. 

### DIFF
--- a/ErodeDilateLabel.s4ext
+++ b/ErodeDilateLabel.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl https://github.com/tokjun/ErodeDilateLabel.git
-scmrevision 0fc1f7cb3524bff337b81cccf38dffc54ba8003b
+scmrevision 0fc1f7c
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files
@@ -15,27 +15,27 @@ scmrevision 0fc1f7cb3524bff337b81cccf38dffc54ba8003b
 depends     NA
 
 # Inner build directory (default is .)
-build_subdirectory inner-build
+build_subdirectory .
 
 # homepage
-homepage     http://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/ErodeDilateLabel
+homepage    http://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/ErodeDilateLabel
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
 # For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)
-contributors Junichi Tokuda (BWH)
+contributors Junichi Tokuda (Brigham and Women's Hospital)
 
 # Match category in the xml description of the module (where it shows up in Modules menu)
-category     Filtering.Morphology
+category    Filtering.Morphology
 
 # url to icon (png, size 128x128 pixels)
-iconurl      http://www.slicer.org/slicerWiki/images/a/ac/ErodeDilateLabelIcon.png
+iconurl     http://www.slicer.org/slicerWiki/images/a/ac/ErodeDilateLabelIcon.png
 
 # Give people an idea what to expect from this code
 #  - Is it just a test or something you stand beind?
 status      
 
 # One line stating what the module does
-description 
+description This extension applies binary erosion and dilation to label maps. The extension uses binary erosion and dilation filters in ITK based on N.Nikopoulos et al. An efficient algorithm for 3d binary morphological transformations with 3d structuring elements for arbitrary size and shape. IEEE Transactions on Image Processing. Vol. 9. No. 3. 2000. pp. 283-286.
 
 # Space separated list of urls
 screenshoturls http://www.slicer.org/slicerWiki/images/d/df/Slicer4-ErodeDilateLabel-GUI.png


### PR DESCRIPTION
The s4ext file is replaced by automatically-generated one. 
