### PR TITLE
ENH: add SegmentationAdiedRegistration extension s4ext

### DIFF
--- a/SegmentationAidedRegistration.s4ext
+++ b/SegmentationAidedRegistration.s4ext
@@ -18,7 +18,7 @@ depends     NA
 build_subdirectory .
 
 # homepage
-homepage    http://www.na-mic.org/Wiki/index.php/SegmentationAidedRegistration
+homepage    http://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Modules/SegmentationAidedRegistration
 
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)


### PR DESCRIPTION
This module is an improved and expanded version for the 
AFibLongitudinalRegistration - Add extension issue #29

this module is able to perform registration of two grayscale images. In particular, when we want high registration accuracy at certain organ, we can segment them and use the binary masks to aid the registration.

After this is tested, the AFibLongitudinalRegistration - Add extension issue #29 can be closed.
