### PR TITLE
Add DiceComputation extension

### DIFF
--- a/DiceComputation.s4ext
+++ b/DiceComputation.s4ext
@@ -1,0 +1,38 @@
+#
+# First token of each non-comment line is the keyword and the rest of the line
+# (including spaces) is the value.
+# - the value can be blank
+#
+
+# This is source code manager (i.e. svn)
+scm git
+scmurl git://github.com/lchauvin/DiceComputation.git
+scmrevision 7a58a74761f0019e0f1ee2b3b7f045b2769a226a 
+
+# list dependencies
+# - These should be names of other modules that have .s4ext files
+# - The dependencies will be built first
+depends NA
+
+# homepage
+homepage    http://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/DiceComputation
+
+# Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
+# For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)
+contributors Laurent Chauvin (BWH)
+
+# Match category in the xml description of the module (where it shows up in Modules menu)
+category    Quantification
+
+# url to icon (png, size 128x128 pixels)
+iconurl    http://wiki.slicer.org/slicerWiki/images/7/79/DiceSimilarityCoefficient.png
+
+# Give people an idea what to expect from this code
+#  - Is it just a test or something you stand beind?
+status      Beta
+
+# One line stating what the module does
+description Compute Dice's Similarity Coefficient (DSC) for several registered label map images.
+
+# Space separated list of urls
+screenshoturls http://wiki.slicer.org/slicerWiki/images/1/1d/Slicer4-DiceComputation-GUI.png


### PR DESCRIPTION
This extension allows users to compute Dice's coefficient for several label maps and compare results and compute some statistics (average, standard deviation, min, max).
It is useful to compare segmentation algorithm for example.
In the future, other values will be added for computation, like sensitivity, specificity, etc...
