### PR TITLE
add explicit depends on Editor, use git-read-only url

### DIFF
--- a/KSlice.s4ext
+++ b/KSlice.s4ext
@@ -4,10 +4,10 @@
 # - the value can be blank
 #
 
-# This is source code manager. Rev: 4 June 2013
+# This is source code manager (i.e. svn)
 scm git
-scmurl git@github.com:pkarasev3/kslice.git
-scmrevision af93fe8
+scmurl git://github.com/pkarasev3/kslice.git
+scmrevision 1117fca
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files


### PR DESCRIPTION
- add dependency statement for editor effect depends on EditorLib
- use read-only URL in the s4ext file as JC suggests

diff set:
https://github.com/pkarasev3/kslice/compare/af93fe89cfdc2e28222aee2eb661a4035673b1c9...slicer
