### PR TITLE
BUG: fix windows compilation bug, see detail below

### DIFF
--- a/SegmentationAidedRegistration.s4ext
+++ b/SegmentationAidedRegistration.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl git://github.com/gaoyi/SegmentationAidedRegistration.git
-scmrevision b923d122bc4e1eb8ea74887153152c4bfdabe33c
+scmrevision 305c6baf0b5539a5f7bb667edf986200a9757336
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files


### PR DESCRIPTION
the previous version causes compilation error in WIndows. Because there are default parameters in function implementation. this is corrected.
