### PR TITLE
ENH: Packaging on MacOS is cleaner and DTIProcess branch for the Slicer ...

### DIFF
--- a/DTIProcess.s4ext
+++ b/DTIProcess.s4ext
@@ -6,8 +6,8 @@
 
 # This is source code manager (i.e. svn)
 scm svn
-scmurl https://www.nitrc.org/svn/dtiprocess/branches/Slicer4Extension
-scmrevision 173
+scmurl https://www.nitrc.org/svn/dtiprocess/trunk
+scmrevision 187
 svnusername slicerbot
 svnpassword slicer
 


### PR DESCRIPTION
...extension has been merge into the trunk

*The packaging process on MacOS was copying some libraries twice while creating the package. This is not the case anymore
*Libraries that are not CLI libraries are not packaged in the cli-modules directory anymore, but in lib/slicer4-2
*DTIProcess extension was build from a specific branch from the svn repository. This branch has been merged into the trunk

New commits: 174 to 187
http://www.nitrc.org/plugins/scmsvn/viewcvs.php/trunk/?root=dtiprocess&view=log
