### PR TITLE
add ModelClip extension

### DIFF
--- a/ModelClip.s4ext
+++ b/ModelClip.s4ext
@@ -35,7 +35,7 @@ iconurl     http://www.slicer.org/slicerWiki/index.php/File:ModelClipIcon.png
 status      
 
 # One line stating what the module does
-description This work was part of the dissertation of my bachelor from SJTU.
+description This module allows to clip models with multiple planes.
 
 # Space separated list of urls
 screenshoturls http://www.slicer.org/slicerWiki/index.php/File:ModelClipScreenShot.png


### PR DESCRIPTION
Hi, jc

This is an extension module to set the osteotomy trajectory with multiple planes, and clip the model with just one click. It is designed for osteotomy simulation. If there's any problem, please contact me or my supervisor. 

Jun Lin.
