### PR TITLE
Updated MatlabBridge extension to 0.2.0.

### DIFF
--- a/MatlabBridge.s4ext
+++ b/MatlabBridge.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm svn
 scmurl https://subversion.assembla.com/svn/slicerrt/trunk/MatlabBridge/src
-scmrevision 943
+scmrevision 957
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files
@@ -35,7 +35,7 @@ iconurl     http://www.slicer.org/slicerWiki/images/e/e8/MatlabBridgeLogo.png
 status      
 
 # One line stating what the module does
-description The Matlab Bridge extension allows running Matlab scripts as command-line interface (CLI) modules directly from 3D Slicer. The only prerequisites for running Matlab scripts are having this extension and Matlab installed on the 3D Slicer computer (building of 3D Slicer, MEX files, etc. is not needed). Module version: 0.1.0.
+description The Matlab Bridge extension allows running Matlab scripts as command-line interface (CLI) modules directly from 3D Slicer. The only prerequisites for running Matlab scripts are having this extension and Matlab installed on the 3D Slicer computer (building of 3D Slicer, MEX files, etc. is not needed). Extension version: 0.2.0.
 
 # Space separated list of urls
 screenshoturls http://www.slicer.org/slicerWiki/images/2/2f/MatlabBridgeScreenshot1.png http://www.slicer.org/slicerWiki/images/1/16/MatlabBridgeScreenshot2.png http://www.slicer.org/slicerWiki/images/b/b9/MatlabBridgeScreenshot3.png


### PR DESCRIPTION
Contents: https://www.assembla.com/spaces/slicerrt/milestones/3876103-matlabbridge-0-2-0
327 Prevent overwriting of existing files in Matlab module generator
328 Remove spaces from module name in Matlab module generator
330 Pass additional module paths to Matlab command server
334 Add Matlab support for more CLI parameters
335 Add support for passing fiducial positions to Matlab scripts
336 Negative number argument values cannot be passed to Matlab modules
337 Add Matlab support for Linux and Mac
338 Return with error code from the CLI if error occurred in the Matlab script
340 Add support for reading and writing transforms
