### PR TITLE
Updated MatlabBridge

### DIFF
--- a/MatlabBridge.s4ext
+++ b/MatlabBridge.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm svn
 scmurl https://subversion.assembla.com/svn/slicerrt/trunk/MatlabBridge/src
-scmrevision 957
+scmrevision 962
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files


### PR DESCRIPTION
Changed cli_pointvectordecode.m to return points in columns to allow transformation by multiplying with a matrix from the left. Fixed examples accordingly.
