### PR TITLE
BUG: Multiple corrections (rev56->59)

### DIFF
--- a/FiberViewerLight.s4ext
+++ b/FiberViewerLight.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm svn
 scmurl https://www.nitrc.org/svn/fvlight/trunk
-scmrevision 55
+scmrevision 59
 svnusername slicerbot
 svnpassword slicer
 


### PR DESCRIPTION
rev59:
BUG: MacOS bugs corrected

-rpath problem solved by passing new rpath value to the linker
-Addition of the launcher (like on windows) to run the executable in an independant process from Slicer. More stable.
https://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=fvlight&revision=59

rev58:
ENH: Build tools are now in the build tree and not in the Slicer build tree

Addition of CMake variables:
 RUNTIME_OUTPUT_DIRECTORY
 LIBRARY_OUTPUT_DIRECTORY
 ARCHIVE_OUTPUT_DIRECTORY

that are given to SEMMacroBuildCLI()
https://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=fvlight&revision=58

rev57:
ENH: removed FiberLengthCleaning.py from the Slicer extension package
https://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=fvlight&revision=57

rev56:
BUG: Do not look for QWT in the system paths when FiberViewerLight is build as a Slicer extension since QWT is build as part of the package
https://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=fvlight&revision=56
