### PR TITLE
Moving Deformation Field Visualizer into its own extension

### DIFF
--- a/TransformVisualizer.s4ext
+++ b/TransformVisualizer.s4ext
@@ -1,0 +1,44 @@
+#
+# First token of each non-comment line is the keyword and the rest of the line
+# (including spaces) is the value.
+# - the value can be blank
+#
+
+# This is source code manager (i.e. svn)
+scm svn
+scmurl https://subversion.assembla.com/svn/slicerrt/trunk/TransformVisualizer/src
+scmrevision 1072
+
+# list dependencies
+# - These should be names of other modules that have .s4ext files
+# - The dependencies will be built first
+depends     NA
+
+# Inner build directory (default is .)
+build_subdirectory .
+
+# homepage
+homepage    http://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/TransformVisualizer
+
+# Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
+# For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)
+contributors Franklin King (PerkLab, Queen's University), Csaba Pinter (PerkLab, Queen's University), Andras Lasso (PerkLab, Queen's University)
+
+# Match category in the xml description of the module (where it shows up in Modules menu)
+category    Registration
+
+# url to icon (png, size 128x128 pixels)
+iconurl     http://www.slicer.org/slicerWiki/images/5/55/TransformVisualizerLogo.png
+
+# Give people an idea what to expect from this code
+#  - Is it just a test or something you stand beind?
+status      
+
+# One line stating what the module does
+description  Extension version: 0.1.0.
+
+# Space separated list of urls
+screenshoturls http://www.slicer.org/slicerWiki/images/f/f7/SlicerRT_DefFieldVisGlyphUI.png http://www.slicer.org/slicerWiki/images/a/aa/SlicerRT_DefFieldVisModels.png
+
+# 0 or 1: Define if the extension should be enabled after its installation.
+enabled 1


### PR DESCRIPTION
Moving Deformation Field Visualizer from SlicerRT into its own extension and renaming it to Transform Visualizer.

https://www.assembla.com/code/slicerrt/subversion/nodes/1072/trunk/TransformVisualizer/src

www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/TransformVisualizer
