### PR TITLE
BUG: Install rule was wrong on linux. It was trying to install FiberView...

### DIFF
--- a/FiberViewerLight.s4ext
+++ b/FiberViewerLight.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm svn
 scmurl https://www.nitrc.org/svn/fvlight/trunk
-scmrevision 59
+scmrevision 60
 svnusername slicerbot
 svnpassword slicer
 


### PR DESCRIPTION
...erLauncher which is build only on Mac and Windows. We added an "if endif" for that rule in CMakeLists.txt

ENH: Remove Slicer_SKIP_PROJECT_COMMAND that is not necessary anymore
BUG: addition of Subversion_SVN_EXECUTABLE to be passed to the sub-projects (Slicer r22241[1])
https://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=fvlight&revision=60
