### PR TITLE
Fixes compilation errors on Windows

### DIFF
--- a/PkModeling.s4ext
+++ b/PkModeling.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl git://github.com/millerjv/PkModeling.git
-scmrevision 0364a32
+scmrevision b42f574dc512c9
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files
@@ -38,7 +38,7 @@ status      Beta
 description PkModeling is a Slicer4 Extension that provides pharmacokinetic modeling for dynamic contrast enhanced MRI (DCE MRI).
 
 # Space separated list of urls
-screenshoturls  
+screenshoturls
 
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 1


### PR DESCRIPTION
Merges two pull requests from Andriy.
1. DCE DICOM support for a different tag
2. Adjustment of a default parameter to match recent literature

Merges one patch from Jim
1. Compilation errors on Windows (and perhaps Linux).

http://github.com/millerjv/PkModeling/compare/0364a...b42f57
