### PR TITLE
use cmake mods for fixing mac build error and hopefully proper installat...

### DIFF
--- a/KSlice.s4ext
+++ b/KSlice.s4ext
@@ -6,8 +6,8 @@
 
 # This is source code manager (i.e. svn)
 scm git
-scmurl git://github.com/pkarasev3/kslice.git
-scmrevision 1117fca
+scmurl git://github.com:pkarasev3/kslice.git
+scmrevision f8865c5
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files


### PR DESCRIPTION
https://github.com/pkarasev3/kslice/compare/1117fca304d07a712309c247fc1233b43723290f...slicer
- hopefully fix mac build error due to compiler flag being different than linux 
- hopefully fix install process not adding scriptedModules path along with loadableModules
