### PR TITLE
fix one-character typo in the .s4ext file

### DIFF
--- a/KSlice.s4ext
+++ b/KSlice.s4ext
@@ -6,7 +6,7 @@
 
 # This is source code manager (i.e. svn)
 scm git
-scmurl git://github.com:pkarasev3/kslice.git
+scmurl git://github.com/pkarasev3/kslice.git
 scmrevision f8865c5
 
 # list dependencies


### PR DESCRIPTION
messed up typing the read-only git url
