### PR TITLE
ENH: GUI problems on MacOS, xml info

### DIFF
--- a/FiberViewerLight.s4ext
+++ b/FiberViewerLight.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm svn
 scmurl https://www.nitrc.org/svn/fvlight/trunk
-scmrevision 60
+scmrevision 61
 svnusername slicerbot
 svnpassword slicer
 


### PR DESCRIPTION
-The GUI now appears on top of Slicer when FiberViewerLight is started as a Slicer extension on MacOS
-Some buttons appeared to small on MacOS (at least on small screens). The maximum size of the qt group including those buttons has been increased
-A version number, an acknowledgment as well as a link to the documentation page on the Slicer wiki have been added to the xml description file

diff: http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=fvlight&revision=61
