### PR TITLE
Update ChangeTrackerPy

### DIFF
--- a/ChangeTracker.s4ext
+++ b/ChangeTracker.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl https://github.com/fedorov/ChangeTrackerPy.git
-scmrevision 47aca45
+scmrevision 9177bbe
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files


### PR DESCRIPTION
BUG: account for the changes in CTK API that caused the self-test and the module
functionality to break

The CTK commit to blame: https://github.com/commontk/CTK/commit/9aa389d2bfbd816b41229b517451912d891bc968#Libs/Widgets/ctkWorkflowButtonBoxWidget.h

Details:
https://github.com/fedorov/ChangeTrackerPy/compare/47aca45...9177bbe
