### PR TITLE
fix link to source code for PortPlacement extension

### DIFF
--- a/PortPlacement.s4ext
+++ b/PortPlacement.s4ext
@@ -6,7 +6,7 @@
 
 # This is source code manager (i.e. svn)
 scm git
-scmurl git://github.com/giogadi/PortPlacement.git
+scmurl git://github.com/giogadi/PortPlacement
 scmrevision 0dd35b09c5c34126d917cc3c0c86cb265a908919
 
 # list dependencies


### PR DESCRIPTION
removed the ".git" at the end of the scmurl field to enable linking to the source code from the Slicer Extensions Manager
