### PR TITLE
ENH: Updated DTIAtlasFiberAnalyzer svn revision

### DIFF
--- a/DTIAtlasFiberAnalyzer.s4ext
+++ b/DTIAtlasFiberAnalyzer.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm svn
 scmurl https://www.nitrc.org/svn/dti_tract_stat/trunk/
-scmrevision 105
+scmrevision 114
 svnusername slicerbot
 svnpassword slicer
 


### PR DESCRIPTION
Revision 114: http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dti_tract_stat&revision=114
BUG: Looks for external executables first in DTIATlasFiberAnalyzer's directory and then in system paths
ENH: dtitractstat now allows to specify a step smaller than 0.1 if the option --rodent is selected.
ENH: DTIAtlasFiberAnalyzer now allows to specify sampling step for fibers
BUG: DTIAtlasFiberAnalyzer was crashing if the CSV file given was a folder
BUG: DTIAtlasFiberAnalyzer was crashing if the CSV file was containing an extra empty line

Revision 113: http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dti_tract_stat&revision=113
BUG: Removing installation bug on Linux introduced by installation on Windows

Revision 112: http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dti_tract_stat&revision=112
BUG: Install windows should work

Revision 111: http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dti_tract_stat&revision=111
BUG: rpath on Mac and main window appearing under Slicer window

Revision 110: http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dti_tract_stat&revision=110
BUG: rpath on Mac and main window appearing under Slicer window

Revision 109: http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dti_tract_stat&revision=109
ENH: Installation process updated and rpath added

Revision 108: http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dti_tract_stat&revision=108
BUG: rpath Mac problem corrected

Revision 107: http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dti_tract_stat&revision=107
BUG: Do not look for QWT in the system paths when dti_tract_stat is build as a Slicer extension since QWT is build as part of the package

Revision 106: http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dti_tract_stat&revision=106
ENH: Applied patch given by Hans Johnson to build dti_tract_stat
