### PR TITLE
ENH: Updated DataStore.s4ext file

### DIFF
--- a/DataStore.s4ext
+++ b/DataStore.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl https://github.com/Slicer/Slicer-DataStore.git
-scmrevision 3c2e0ed
+scmrevision a9c1bb9
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files


### PR DESCRIPTION
For some reason (probably a mistake I did), the previous change did not update the module's revision number.

https://github.com/charles-marion/ExtensionsIndex/compare/update-DataStore
