### PR TITLE
Added numeration in workflow steps collapsible buttons

### DIFF
--- a/LongitudinalPETCT.s4ext
+++ b/LongitudinalPETCT.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl https://github.com/paulcm/LongitudinalPETCT
-scmrevision 9b6d4b8
+scmrevision d033772
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files


### PR DESCRIPTION
Compare View Link: https://github.com/paulcm/LongitudinalPETCT/compare/9b6d4b8fb119fe538a2956288bd2e50ba15dfa5b...master

Follow-up commit after major Longitudinal PET/CT Analysis Extension update which included the following changes:

DICOM Plugin updates:

```
DICOMLoadable caching for performance improvement
Selection from multiple CTs for PET
PET only support
Usage of PETSUVImageMaker module to generate normalized volumes
```

Module updates:

```
Registration of PET/CT studies image volumes
Quantification: use of PETSUVImageMaker for SUV normalized PET image volumes
Module settings sidebar
PET color selection presets
CT Window/Level selection presets
ReportOverview Table provides statistics in cells
Additional segmentation statistics: StdDev, Count, Volcc, Volmm3
```
