### PR TITLE
COMP: update-RSSExtension

### DIFF
--- a/RSSExtension.s4ext
+++ b/RSSExtension.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl git://github.com/gaoyi/RSSExtension.git
-scmrevision 611d981ec4f96d04c4f7c2da99d17086454a8db9
+scmrevision d447085
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files
@@ -28,7 +28,7 @@ contributors Yi Gao (UAB), Ron Kikinis (BWH), Sylvain Bouix (BWH), Martha Shento
 category    Segmentation
 
 # url to icon (png, size 128x128 pixels)
-iconurl     http://www.slicer.org/slicerWiki/images/b/ba/SegAidedRegSquareFocus128.png
+iconurl     http://viewvc.slicer.org/viewvc.cgi/Slicer4/trunk/Extensions/Testing/RSSExtension/RSSExtension.png?revision=21746&view=co
 
 # Give people an idea what to expect from this code
 #  - Is it just a test or something you stand beind?


### PR DESCRIPTION
fixed some build issues caused by typename in non-template files

compare view:

https://github.com/gaoyi/RSSExtension/compare/611d981ec4f96d04c4f7c2da99d17086454a8db9…d447085b3955abb460a8c39e48af925132dd8920

i'm using gcc4.6.3 locally and didn't detect those compilation errors. is there a way to set the compiler flags so that i can detect those problem earlier?

Thanks!
yi
