### PR TITLE
BUG: Update rss extension

### DIFF
--- a/RSSExtension.s4ext
+++ b/RSSExtension.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl git://github.com/gaoyi/RSSExtension.git
-scmrevision a0260ae4a03c70ba6c3d328d491cfb20afd8e1b1
+scmrevision 2be89dfac932bfae034ee43c87b6383782c1fb33
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files


### PR DESCRIPTION
```
fix a bug: the mask image is not init-ed to all 0, which causes problem

fix a bug: mistake in computing kappa

clean up some debuging code
```

compare view:

https://github.com/gaoyi/RSSExtension/compare/d447085b3955abb460a8c39e48af925132dd8920…2be89dfac932bfae034ee43c87b6383782c1fb33
