### PR TITLE
Fixed typo in header include

### DIFF
--- a/LongitudinalPETCT.s4ext
+++ b/LongitudinalPETCT.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl https://github.com/paulcm/LongitudinalPETCT
-scmrevision d033772
+scmrevision 07c8e77
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files


### PR DESCRIPTION
Compare View Link: https://github.com/paulcm/LongitudinalPETCT/compare/d033772ca44deabd2587abfb8a3dde006e6ad94a...07c8e77226a5b4678a89ca1ecfeacc8fcd4ca91b

Typo caused build errors on Linux because of case sensitivity.
