### PR TITLE
Changed default setting for registration and model making to active

### DIFF
--- a/LongitudinalPETCT.s4ext
+++ b/LongitudinalPETCT.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl https://github.com/paulcm/LongitudinalPETCT
-scmrevision 07c8e77
+scmrevision 7c06d40
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files


### PR DESCRIPTION
Compare view link: https://github.com/paulcm/LongitudinalPETCT/compare/07c8e77...7c06d40

Registration and model making are now active by default so that the users do not have to select them first.
