### PR TITLE
Add CMFreg extension

### DIFF
--- a/CMFreg.s4ext
+++ b/CMFreg.s4ext
@@ -1,0 +1,44 @@
+#
+# First token of each non-comment line is the keyword and the rest of the line
+# (including spaces) is the value.
+# - the value can be blank
+#
+
+# This is source code manager (i.e. svn)
+scm git
+scmurl https://github.com/viboen/CMFreg.git
+scmrevision 1714e28
+
+# list dependencies
+# - These should be names of other modules that have .s4ext files
+# - The dependencies will be built first
+depends     NA
+
+# Inner build directory (default is .)
+build_subdirectory .
+
+# homepage
+homepage    http://www.slicer.org/slicerWiki/index.php/Documentation/4.3/Extensions/CMFreg
+
+# Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
+# For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)
+contributors Vinicius Boen (Univ of Michigan), Manson Winsauer(UNC)
+
+# Match category in the xml description of the module (where it shows up in Modules menu)
+category    Registration
+
+# url to icon (png, size 128x128 pixels)
+iconurl     http://www.slicer.org/slicerWiki/images/b/bc/BaselineFollowupSCANRegisteredCMFreg2.png
+
+# Give people an idea what to expect from this code
+#  - Is it just a test or something you stand beind?
+status      
+
+# One line stating what the module does
+description Tools package for the cranio-maxillofacial registration
+
+# Space separated list of urls
+screenshoturls http://www.slicer.org/slicerWiki/images/1/15/BaselineFollowupSCANCMFreg.png http://www.slicer.org/slicerWiki/images/0/0b/GrowingInterface.png http://www.slicer.org/slicerWiki/images/4/4a/InputSegToExtractionCMFreg.png http://www.slicer.org/slicerWiki/images/4/46/BaselineSegmentationMaskCMFreg.png
+
+# 0 or 1: Define if the extension should be enabled after its installation.
+enabled 1


### PR DESCRIPTION
A registration package oriented to the Dental Research community. The registration package will perform superimposition using diverse Cranio-Maxillofacial CMF areas as stable regions of reference. This package provides several modules. Mathematical operations on label maps, mask creation, matrix application and non-growing/growing registrations.

http://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/CMFreg
https://sites.google.com/a/umich.edu/dentistry-image-computing/Clinical-Applications/3d-registration---longitudinal-and-across-subjects
