### PR TITLE
FIX: Fixed volume rendering related memory leak.

### DIFF
--- a/LongitudinalPETCT.s4ext
+++ b/LongitudinalPETCT.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl https://github.com/paulcm/LongitudinalPETCT
-scmrevision 7c06d40
+scmrevision 7f76f6e
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files


### PR DESCRIPTION
Compare View Link: https://github.com/paulcm/LongitudinalPETCT/compare/7c06d40...7f76f6e

Fixed memory leak caused by incorrect volume rendering node creation in Python after reading:
http://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Modules/VolumeRendering#How_Tos
