### PR TITLE
update CMFreg: ADD new python script model - SurfaceRegistration

### DIFF
--- a/CMFreg.s4ext
+++ b/CMFreg.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl https://github.com/viboen/CMFreg.git
-scmrevision 1714e28
+scmrevision a357ce3
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files


### PR DESCRIPTION
The big change was the addition of a python script to surface registration:
https://github.com/viboen/CMFreg/commit/5f08bc511e94d42c885e67062413da2462ad422b
https://github.com/viboen/CMFreg/commit/b7f82016202dda4e3b70feff3b49b2033306c541

The other changes was to try to fix a mac's issue. It include changes at the CMakeLists.txt:
https://github.com/viboen/CMFreg/commit/a357ce31ddaf023a397a06e2a04921ccb352d1cc
https://github.com/viboen/CMFreg/commit/dbd8ccb1ac530078413ec8bc905de2a257a65c5c

and changes in the .cxx file:
https://github.com/viboen/CMFreg/commit/29020c4b45bbd0b2438a9bd7a3d51f18818a1f22
