### PR TITLE
BUG: Fixed bug that caused limited visibility of SUV result plots.

### DIFF
--- a/LongitudinalPETCT.s4ext
+++ b/LongitudinalPETCT.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl https://github.com/paulcm/LongitudinalPETCT
-scmrevision 4add76f
+scmrevision 88db0f1
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files


### PR DESCRIPTION
Compare View Link: https://github.com/paulcm/LongitudinalPETCT/compare/7f76f6e...88db0f1

Due to a semantic error in the code only the first set of SUV results was plotted even when multiple sets were available. This bug has been fixed and unused code was removed.
