### PR TITLE
moved iGyne repository

### DIFF
--- a/iGynePy.s4ext
+++ b/iGynePy.s4ext
@@ -1,0 +1,44 @@
+#
+# First token of each non-comment line is the keyword and the rest of the line
+# (including spaces) is the value.
+# - the value can be blank
+#
+
+# This is source code manager (i.e. svn)
+scm git
+scmurl https://github.com/gpernelle/iGyne.git
+scmrevision 988097042c0a33b5b5fbc60b7a6eb6cd13340c60
+
+# list dependencies
+# - These should be names of other modules that have .s4ext files
+# - The dependencies will be built first
+depends     NA
+
+# Inner build directory (default is .)
+build_subdirectory .
+
+# homepage
+homepage    http://www.slicer.org/slicerWiki/index.php/Documentation/4.2/Extensions/iGynePy
+
+# Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
+# For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)
+contributors Guillaume Pernelle,  Alireza Mehrtash, Lauren Barber, Nabgha Fahrat, Jan Egger, Tobias Penzkofer, Sandy Wells, Sam Song, Xiaojun Chen, Yi Gao, Antonio Damato, Tina Kapur, Akila Viswanathan
+
+# Match category in the xml description of the module (where it shows up in Modules menu)
+category    IGT
+
+# url to icon (png, size 128x128 pixels)
+iconurl     http://www.slicer.org/slicerWiki/images/9/90/IGynePyIcon.png
+
+# Give people an idea what to expect from this code
+#  - Is it just a test or something you stand beind?
+status      
+
+# One line stating what the module does
+description iGyne is an open source software for MR-Guided Interstitial Gynecologic Brachytherapy. It enables on-time processing of the intra-operative MRI data via a DICOM connection to the scanner followed by a multi-stage registration of CAD models of the template and the obturator to the patient images. This allows the virtual placement of interstitial needles during the intervention, as well as the detection/labeling of needles in MR images
+
+# Space separated list of urls
+screenshoturls http://www.slicer.org/slicerWiki/images/5/5d/IGyne-labelingResult.png
+
+# 0 or 1: Define if the extension should be enabled after its installation.
+enabled 1


### PR DESCRIPTION
Rename iGyne repository.

This commit is follow up of 96d3c5a2.

It changes both the extension repository and extension name to an 
implementation agnostic name.

It implements the last version of the needle segmentation algorithm as well as a new method for CAD model registration.

Debug comments have been disable from printing in the python console.
