### PR TITLE
Update LASegmenter 4.3

### DIFF
--- a/LASegmenter.s4ext
+++ b/LASegmenter.s4ext
@@ -6,8 +6,8 @@
 
 # This is source code manager (i.e. svn)
 scm git
-scmurl git://github.com/ljzhu/LASegmenter.git
-scmrevision 3571ad6
+scmurl git://github.com:ljzhu/LASegmenter.git
+scmrevision 167c386
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files
@@ -22,7 +22,7 @@ homepage    http://www.slicer.org/slicerWiki/index.php?title=Documentation/Night
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
 # For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)
-contributors LiangJia Zhu (UAB), Yi Gao (BWH), Josh Cates (Utah), Alan Morris (Utah), Danny Perry (Utah), Greg Gardner (Utah), Rob MacLeod (Utah), Allen Tannenbaum (UAB) 
+contributors Liangjia Zhu (SBU), Yi Gao (UAB), Josh Cates (Utah), Alan Morris (Utah), Danny Perry (Utah), Greg Gardner (Utah), Rob MacLeod (Utah), Allen Tannenbaum (SBU) 
 
 # Match category in the xml description of the module (where it shows up in Modules menu)
 category    Segmentation


### PR DESCRIPTION
Hi JC,

The module LASegmenter hasn't been updated yet in Slicer 4.3. Here is the latest version. The compare link is 
https://github.com/ljzhu/LASegmenter/compare/1f672da...167c386

Please let me know if there is any issue.

Thanks, 
