### PR TITLE
update LAScarSegmenter in Slicer 4.3

### DIFF
--- a/LAScarSegmenter.s4ext
+++ b/LAScarSegmenter.s4ext
@@ -6,8 +6,8 @@
 
 # This is source code manager (i.e. svn)
 scm git
-scmurl git://github.com/ljzhu/LAScarSegmenter.git
-scmrevision 61a4c5f
+scmurl git://github.com:ljzhu/LAScarSegmenter.git
+scmrevision 869f22f
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files
@@ -22,7 +22,7 @@ homepage     http://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Ex
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
 # For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)
-contributors LiangJia Zhu (UAB), Yi Gao (BWH), Josh Cates (Utah), Alan Morris (Utah), Danny Perry (Utah), Greg Gardner (Utah), Rob MacLeod (Utah), Allen Tannenbaum (UAB) 
+contributors Liangjia Zhu (SBU), Yi Gao (UAB), Josh Cates (Utah), Alan Morris (Utah), Danny Perry (Utah), Greg Gardner (Utah), Rob MacLeod (Utah), Allen Tannenbaum (SBU) 
 
 # Match category in the xml description of the module (where it shows up in Modules menu)
 category    Segmentation


### PR DESCRIPTION
Hi JC,

This module hasn't been updated in Slicer 4.3. This is the latest version. The compare link is at 
https://github.com/ljzhu/LAScarSegmenter/compare/75b4340...869f22f

Please let me know for any issue.

Thanks,

LiangJia 
