### PR TITLE
update LASegmenter: fix an identifier error in windows build

### DIFF
--- a/LASegmenter.s4ext
+++ b/LASegmenter.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl git://github.com/ljzhu/LASegmenter.git
-scmrevision 167c386
+scmrevision a1a622f
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files


### PR DESCRIPTION
Hi JC,

Could you please merge this update into Slicer:master? The compare link is at https://github.com/ljzhu/LASegmenter/compare/167c386...a1a622f.

Thanks,

LJ
