### PR TITLE
Bug fixes related to image and icon paths, testing files.

### DIFF
--- a/XNATSlicer.s4ext
+++ b/XNATSlicer.s4ext
@@ -1,13 +1,13 @@
 #
 # First token of each non-comment line is the keyword and the rest of the line
 # (including spaces) is the value.
-# - the value can be blank.  SUNIL KUMAR: Test comment
+# - the value can be blank
 #
 
 # This is source code manager (i.e. svn)
 scm git
 scmurl https://github.com/skumar221/XNATSlicer.git
-scmrevision 34a7a7f
+scmrevision 34a7a7f752
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files


### PR DESCRIPTION
1) Github (at least on OS X) is case-insensitive with its paths, so the extensions index image references were returning blanks.
2) Commented out any automated testing code -- to be fleshed out at a later time.
