### PR TITLE
COMP: Include vtkObjectFactory.h to address compile error reported in Slicer bug tracking #3493

### DIFF
--- a/TrackerStabilizer.s4ext
+++ b/TrackerStabilizer.s4ext
@@ -7,6 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl git://github.com/SlicerIGT/TrackerStabilizer.git
+scmrevision 8c812eae3c121d6b6e9bc9bd2109e212fb0ce336
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files


### PR DESCRIPTION
https://github.com/lchauvin/TrackerStabilizer/compare/ea3274b7a0...8c812eae3c
