### PR TITLE
BUG: Wrong variable was used. DTIPrep_BUILD_SLICER_EXTENSION was used in...

### DIFF
--- a/FiberViewerLight.s4ext
+++ b/FiberViewerLight.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm svn
 scmurl https://www.nitrc.org/svn/fvlight/trunk
-scmrevision 61
+scmrevision 65
 svnusername slicerbot
 svnpassword slicer
 


### PR DESCRIPTION
...stead of FiberViewerLight_BUILD_SLICER_EXTENSION
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=fvlight&revision=65
ENH: Removed dependencies that were not necessary when compiled as a Slicer extension
BUG: QWT_Library information was handled incorrectly when FiberViewerLight was build as a Superbuild and not as an extension
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=fvlight&revision=64
BUG: Update of Superbuild. It is possible to build FiberViewerLight as a Superbuild project even if it is build as a Slicer extension
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=fvlight&revision=63
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=fvlight&revision=62
