### PR TITLE
BUG: std::isnan doesn't exist on Windows. Builds DTIAtlasFiberAnalyzerLa...

### DIFF
--- a/DTIAtlasFiberAnalyzer.s4ext
+++ b/DTIAtlasFiberAnalyzer.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm svn
 scmurl https://www.nitrc.org/svn/dti_tract_stat/trunk/
-scmrevision 105
+scmrevision 125
 svnusername slicerbot
 svnpassword slicer
 


### PR DESCRIPTION
...uncher even on Linux
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dti_tract_stat&revision=125
ENH: Updated DTIProcess version and better packaging for Slicer extension
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dti_tract_stat&revision=124
BUG: Updated Superbuild issues. Extension_DIR was set when using Superbuild even if FiberViewerLight was not build as an extension
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dti_tract_stat&revision=123
BUG: Tests were not performed if DTIAtlasFiberAnalyzer was built as an extension
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dti_tract_stat&revision=122
STYLE: Since there was already a tag "dti_tract_stat_1.4" on NITRC, the version number of DTIAtlasFiberAnalyzer in its xml description file was changed to 1.4.1
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dti_tract_stat&revision=121
COMP: Add required parameters to SEMMacroBuildCLI for FiberCompare
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dti_tract_stat&revision=120
BUG: inverse_rescale_p_value was not declared in void Processing::WritingDataInVTK
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dti_tract_stat&revision=119
ENH: MergeStatWithFiber: Allows to inverse the p-value mapping
ENH: MergeStatWithFiber: Maps Arclength using the closest fiber point
ENH: dtitractstat: rewrote sorting functions using std::sort
ENH: dtitractstat: Addition of a function to save the original fibers with the arclength as a scalar field
BUG: dtitractstat: Rewrote arclength computation function
BUG: dtitractstat: If "ad" is given as a command line argument, it is modified internally to be interpreted as "l1"
ENH: dtitractstat: Computation of statistics stops before last fiber point instead of after last final point
ENH: DTIAtlasFiberAnalyzer: Saves original fibers with new arclength field instead of resampled fibers
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dti_tract_stat&revision=118
ENH: SuperBuild passes Subversion_SVN_EXECUTABLE to its subprojects
BUG: DTIAtlasFiberAnalyser_BINARY_DIR & DTIAtlasFiberAnalyser_SOURCE_DIR had been removed from DTIAtlasFiberAnalyzer's CMakeLists.txt
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dti_tract_stat&revision=117
BUG: Launcher.cxx had not been added
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dti_tract_stat&revision=116
COMP: trouble building within NamicExternalProjects
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dti_tract_stat&revision=115
BUG: Looks for external executables first in DTIATlasFiberAnalyzer's directory and then in system paths
ENH: dtitractstat now allows to specify a step smaller than 0.1 if the option --rodent is selected.
ENH: DTIAtlasFiberAnalyzer now allows to specify sampling step for fibers
BUG: DTIAtlasFiberAnalyzer was crashing if the CSV file given was a folder
BUG: DTIAtlasFiberAnalyzer was crashing if the CSV file was containing an extra empty line
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dti_tract_stat&revision=114
BUG: Removing installation bug on Linux introduced by installation on Windows
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dti_tract_stat&revision=113
BUG: Install windows should work
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dti_tract_stat&revision=112
BUG: rpath on Mac and main window appearing under Slicer window
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dti_tract_stat&revision=111
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dti_tract_stat&revision=110
ENH: Installation process updated and rpath added
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dti_tract_stat&revision=109
BUG: rpath Mac problem corrected
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dti_tract_stat&revision=108
BUG: Do not look for QWT in the system paths when dti_tract_stat is build as a Slicer extension since QWT is build as part of the package
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dti_tract_stat&revision=107
ENH: Applied patch given by Hans Johnson to build dti_tract_stat
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dti_tract_stat&revision=106
