### PR TITLE
Updated MatlabBridge to 0.10.0

### DIFF
--- a/MatlabBridge.s4ext
+++ b/MatlabBridge.s4ext
@@ -35,7 +35,7 @@ iconurl     http://www.slicer.org/slicerWiki/images/e/e8/MatlabBridgeLogo.png
 status      
 
 # One line stating what the module does
-description The Matlab Bridge extension allows running Matlab scripts as command-line interface (CLI) modules directly from 3D Slicer. The only prerequisites for running Matlab scripts are having this extension and Matlab installed on the 3D Slicer computer (building of 3D Slicer, MEX files, etc. is not needed). Extension version: 0.9.0.
+description The Matlab Bridge extension allows running Matlab scripts as command-line interface (CLI) modules directly from 3D Slicer. The only prerequisites for running Matlab scripts are having this extension and Matlab installed on the 3D Slicer computer (building of 3D Slicer, MEX files, etc. is not needed). Extension version: 0.10.0.
 
 # Space separated list of urls
 screenshoturls http://www.slicer.org/slicerWiki/images/2/2f/MatlabBridgeScreenshot1.png http://www.slicer.org/slicerWiki/images/1/16/MatlabBridgeScreenshot2.png http://www.slicer.org/slicerWiki/images/b/b9/MatlabBridgeScreenshot3.png


### PR DESCRIPTION
Fixed loading of uint8 volumes.
Fixed Matlab launching on Mac OS X.

See details at:
https://www.assembla.com/spaces/slicerrt/milestones/4761013-matlabbridge-0-10-0
