### PR TITLE
Update TCIABrowser

### DIFF
--- a/TCIABrowser.s4ext
+++ b/TCIABrowser.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl https://github.com/QIICR/TCIABrowser.git
-scmrevision 1680061
+scmrevision ccbbae8bcf
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files


### PR DESCRIPTION
- correct the revision number, as the old one was invalid after repository
  transfer
- new revision includes the icon

Compare link is not available since the repository has changed, and the
old revision number refers to a non-existent repository.
