### PR TITLE
Update SPHARM-PDM

### DIFF
--- a/SPHARM-PDM.s4ext
+++ b/SPHARM-PDM.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm svn
 scmurl https://www.nitrc.org/svn/spharm-pdm
-scmrevision 215
+scmrevision 216
 svnusername slicerbot
 svnpassword slicer
 


### PR DESCRIPTION
ENH: Addition of find_package(Subversion) to build correctly the extension on the Windows factory, and moved find_package(git) to Common.cmake

http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=spharm-pdm&revision=216
