### PR TITLE
Add GyroGuide extension

### DIFF
--- a/GyroGuide.s4ext
+++ b/GyroGuide.s4ext
@@ -28,7 +28,7 @@ contributors Ruifeng Chen, Luping Fang, Qing Pan (College of Information Enginee
 category    IGT
 
 # url to icon (png, size 128x128 pixels)
-iconurl     http://www.slicer.org/slicerWiki/index.php/File:GyroGuide.png
+iconurl     http://www.slicer.org/slicerWiki/images/a/a7/GyroGuide.png
 
 # Give people an idea what to expect from this code
 #  - Is it just a test or something you stand beind?


### PR DESCRIPTION
In neurosurgery, it is essential to determine the trajectory angle and
depth. Furthermore, the angle and depth have to be transmitted to the
probe for real time navigation. This extension implements these
functions. First, it calculates the entering angle and depth between the
probe and the reference planes based on CT/MRI scan. Then, the
calculated parameters can be transmitted to a gyroscope-based device
which is attached to the probe. The surgeons can be guided to operate
precisely by matching the output of gyroscope with the calculated angle,
and comparing the scale on the probe and the calculated depth.
