### PR TITLE
ENH: Update dtiprocess version from r187 to r213

### DIFF
--- a/DTIProcess.s4ext
+++ b/DTIProcess.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm svn
 scmurl https://www.nitrc.org/svn/dtiprocess/trunk
-scmrevision 187
+scmrevision 213
 svnusername slicerbot
 svnpassword slicer
 


### PR DESCRIPTION
ENH: Enable storing of DTI properties as separate scalar point data
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dtiprocess&revision=213
BUG: To perform ExperimentalUpload, EXTENSION_SUPERBUILD_BINARY_DIR needs to be defined. It was not defined anymore since we had removed include(Slicer_USE_FILE)
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dtiprocess&revision=212
ENH: Updated the Superbuild system to add find_package(Subversion) and find_package(git) as well as remove the inclusion of
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dtiprocess&revision=211
BUG: property 'svn:externals' deleted from 'IowaChanges20100105'
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dtiprocess&revision=210
BUG: Branch dwiAtlas_Debug_Wendy was removed
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dtiprocess&revision=209
ENH: Branch ITKv4 was removed because it couldn't download
'https://www.nitrc.org/svn/brains/BRAINSExecutionModel/trunk
and because it was not used anymore
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dtiprocess&revision=208
ENH: remove DWIPrivateLibrary that was empty and improvement of packaging as a Slicer extension
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dtiprocess&revision=207
ENH: By default, compilation of all the tools statically
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dtiprocess&revision=206
BUG: dtiestimDTI_WLS_Test was not passing. We updated the test and the baseline image
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dtiprocess&revision=205
COMP: Make building more robust.
When building against external ITK with DCMTK (as in slicer) the DCMTK find package was not very robust in the default cmake utilitities.  Thsi makes a more robust version that allows superbuild to be more robust.
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dtiprocess&revision=204
BUG: Fix Cmake warning
DTIProcess/CMake/SlicerExtensionsConfigureMacros.cmake:144:28
Argument not separated from preceding token by whitespace.
DTIProcess/CMake/SlicerExtensionsConfigureMacros.cmake:174:50
Argument not separated from preceding token by whitespace.
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dtiprocess&revision=203
COMP: got rid of need for itkV3Compatibility
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dtiprocess&revision=202
ENH: Modification of dtiestim version to 1.1.2 after last modification ( mask filter precision)
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dtiprocess&revision=201
ENH: Addition of a larger tolerance for direction and origin difference when applying a mask filter. New tolerance set to 0.001 instead of default tolerance (1e-06).
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dtiprocess&revision=200
ENH: Let the choice to change INSTALL_\* directories
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dtiprocess&revision=199
BUG: removed a warning form fibertrack
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dtiprocess&revision=198
ENH&BUG: Install paths were not given from Superbuild project and static compila
tion had problems. Addition of a possibility to Superbuild the project independe
ntly from being an extension
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dtiprocess&revision=197
BUG: this->ProcessObject::GetOutput(1) must be a valid output or program segmentation faults.
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dtiprocess&revision=196
ENH: Remove old command line parser commented out code.
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dtiprocess&revision=195
ENH: Verification of the version of ITK chosen. Warning message if wrong version chosen. This verification was done only if ITK was not found, which was a bug
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dtiprocess&revision=194
STYLE: Remove debugging statements in configure step.
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dtiprocess&revision=193
COMP: TransformWriter is more strict in ITKv4.5 about type matching
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dtiprocess&revision=192
STYLE: Remove unnecessary file.
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dtiprocess&revision=191
COMP: Fixed compilation with new SlicerExecutionModel
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dtiprocess&revision=190
ENH: allow mask to be different in origin and spacing
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dtiprocess&revision=189
ENH: ctest when stand-alone and executable-only build option
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dtiprocess&revision=188
