### PR TITLE
ENH: Update FiberViewerLight from r65 to r68

### DIFF
--- a/FiberViewerLight.s4ext
+++ b/FiberViewerLight.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm svn
 scmurl https://www.nitrc.org/svn/fvlight/trunk
-scmrevision 65
+scmrevision 68
 svnusername slicerbot
 svnpassword slicer
 


### PR DESCRIPTION
BUG: To perform ExperimentalUpload, EXTENSION_SUPERBUILD_BINARY_DIR needs to be defined. It was not defined anymore since we had removed include()
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=fvlight&revision=68
ENH: Reorganization of CMake to add find_package(git) and find_package(Subversion) in Common.cmake
ENH: Reorganization of FiberViewerLight.cmake to look for SlicerExecutionModel before ITK
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=fvlight&revision=67
BUG: FiberViewerLight was including  when compiled as an extension. Doing this was including some Slicer CMake files. This used to work because those Slicer CMake files were the same as the CMake files contained in FiberViewerLight. In the latest version of Slicer, those files have changed and this was creating an incompatibility.  is not included anymore to avoid those conflicts
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=fvlight&revision=66
