### PR TITLE
ENH: Update DTIAtlasFiberAnalyzer from r114 to r128

### DIFF
--- a/DTIAtlasFiberAnalyzer.s4ext
+++ b/DTIAtlasFiberAnalyzer.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm svn
 scmurl https://www.nitrc.org/svn/dti_tract_stat/trunk/
-scmrevision 114
+scmrevision 128
 svnusername slicerbot
 svnpassword slicer
 


### PR DESCRIPTION
BUG: To perform ExperimentalUpload, EXTENSION_SUPERBUILD_BINARY_DIR needs to be defined. It was not defined anymore since we had removed include(Slicer_USE_FILE)
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dti_tract_stat&revision=128
ENH: Updated dtiprocess version compiled to latest version (r211)
ENH: Update ITK version compiled by SuperBuild
BUG: Removed include(${Slicer_USE_FILE}) which was not necessary and was creating issues by including Superbuild files from Slicer when package was build as an extension instead of using the files included in the current package
BUG: Superbuild was not working because of missing RUNTIME_INSTALL setting for DTIAtlasFiberAnalyzer when not built as an extension
ENH: Addition of find_package(Subversion) and find_package(git) in case those are not in the PATH of the system
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dti_tract_stat&revision=127
BUG: FiberViewerLight was including  when compiled as an extension. Doing this was including some Slicer CMake files. This used to work because those Slicer CMake files were the same as the CMake files contained in FiberViewerLight. In the latest version of Slicer, those files have changed and this was creating an incompatibility.  is not included anymore to avoid those conflicts
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dti_tract_stat&revision=126
BUG: std::isnan doesn't exist on Windows. Builds DTIAtlasFiberAnalyzerLauncher even on Linux
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dti_tract_stat&revision=125
ENH: Updated DTIProcess version and better packaging for Slicer extension
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dti_tract_stat&revision=124
BUG: Updated Superbuild issues. Extension_DIR was set when using Superbuild even if FiberViewerLight was not build as an extension
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dti_tract_stat&revision=123
BUG: Tests were not performed if DTIAtlasFiberAnalyzer was built as an extension
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dti_tract_stat&revision=122
STYLE: Since there was already a tag "dti_tract_stat_1.4" on NITRC, the version number of DTIAtlasFiberAnalyzer in its xml description file was changed to 1.4.1
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dti_tract_stat&revision=121
COMP: Add required parameters to SEMMacroBuildCLI for FiberCompare
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dti_tract_stat&revision=120
BUG: inverse_rescale_p_value was not declared in void Processing::WritingDataInVTK
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dti_tract_stat&revision=119
MergeStatWith Fiber
ENH: Allows to inverse the p-value mapping
ENH: Maps Arclength using the closest fiber point
dtitractstat
ENH: rewrote sorting functions using std::sort
ENH: Addition of a function to save the original fibers with the arclength as a scalar field
BUG: Rewrote arclength computation function
BUG: If "ad" is given as a command line argument, it is modified internally to be interpreted as "l1"
ENH: Computation of statistics stops before last fiber point instead of after last final point
DTIAtlasFiberAnalyzer:
ENH: Saves original fibers with new arclength field instead of resampled fibers
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dti_tract_stat&revision=118
ENH: SuperBuild passes Subversion_SVN_EXECUTABLE to its subprojects
BUG: DTIAtlasFiberAnalyser_BINARY_DIR & DTIAtlasFiberAnalyser_SOURCE_DIR had been removed from DTIAtlasFiberAnalyzer's CMakeLists.txt
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dti_tract_stat&revision=117
BUG: Launcher.cxx had not been added
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dti_tract_stat&revision=116
COMP: trouble building within NamicExternalProjects
Error message from SEMMacroBuildCLI that INSTALL_RUNTIME_DESTINATION
is not defined. Not sure if this will bother Slicer.
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dti_tract_stat&revision=115
