### PR TITLE
ENH: Update DTIAtlasFiberAnalyzer from r125 to r128

### DIFF
--- a/DTIAtlasFiberAnalyzer.s4ext
+++ b/DTIAtlasFiberAnalyzer.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm svn
 scmurl https://www.nitrc.org/svn/dti_tract_stat/trunk/
-scmrevision 125
+scmrevision 128
 svnusername slicerbot
 svnpassword slicer
 


### PR DESCRIPTION
BUG: To perform ExperimentalUpload, EXTENSION_SUPERBUILD_BINARY_DIR needs to be defined. It was not defined anymore since we had removed include(Slicer_USE_FILE)
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dti_tract_stat&revision=128
ENH: Updated dtiprocess version compiled to latest version (r211)
ENH: Update ITK version compiled by SuperBuild
BUG: Removed include(${Slicer_USE_FILE}) which was not necessary and was creating issues by including Superbuild files from Slicer when package was build as an extension instead of using the files included in the current package
BUG: Superbuild was not working because of missing RUNTIME_INSTALL setting for DTIAtlasFiberAnalyzer when not built as an extension
ENH: Addition of find_package(Subversion) and find_package(git) in case those are not in the PATH of the system
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dti_tract_stat&revision=127
BUG: FiberViewerLight was including  when compiled as an extension. Doing this was including some Slicer CMake files. This used to work because those Slicer CMake files were the same as the CMake files contained in FiberViewerLight. In the latest version of Slicer, those files have changed and this was creating an incompatibility.  is not included anymore to avoid those conflicts
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dti_tract_stat&revision=126
