### PR TITLE
BUG: Updating DTIProcess from r213 to r214

### DIFF
--- a/DTIProcess.s4ext
+++ b/DTIProcess.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm svn
 scmurl https://www.nitrc.org/svn/dtiprocess/trunk
-scmrevision 213
+scmrevision 214
 svnusername slicerbot
 svnpassword slicer
 


### PR DESCRIPTION
BUG: Searching for SVN and passing its path in the Superbuild process to compile as a Slicer extension. The value of this variable seems to be required:
http://slicer.cdash.org/viewBuildError.php?buildid=192440

http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dtiprocess&revision=214
