### PR TITLE
ENH: Update DTIAtlasFiberAnalyzer from r128 to r130

### DIFF
--- a/DTIAtlasFiberAnalyzer.s4ext
+++ b/DTIAtlasFiberAnalyzer.s4ext
@@ -7,14 +7,14 @@
 # This is source code manager (i.e. svn)
 scm svn
 scmurl https://www.nitrc.org/svn/dti_tract_stat/trunk/
-scmrevision 128
+scmrevision 130
 svnusername slicerbot
 svnpassword slicer
 
 #list dependencies
 # - These should be names of other modules that have .s4ext files
 # - The dependencies will be built first
-depends     DTIProcess
+depends  NA
 
 # Inner build directory (default is .)
 build_subdirectory dti_tract_stat-build


### PR DESCRIPTION
BUG: On Windows, the extension of the executable has to be set for the tests to pass. the variable 'extension' was used instead of 'fileextension'
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dti_tract_stat&revision=130

BUG: Updated version of DTIProcess that is compiled as part of DTIAtlasFiberAnalyzer and addition of CMake variables to the DTIProcess ExternalProject so that it can build as an extension
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dti_tract_stat&revision=129
