### PR TITLE
ENH: Update DTIAtlasFiberAnalyzer from r130 to r131

### DIFF
--- a/DTIAtlasFiberAnalyzer.s4ext
+++ b/DTIAtlasFiberAnalyzer.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm svn
 scmurl https://www.nitrc.org/svn/dti_tract_stat/trunk/
-scmrevision 130
+scmrevision 131
 svnusername slicerbot
 svnpassword slicer
 


### PR DESCRIPTION
ENH: Remove unecessary includes in the CMakeLists files to shorten the compilation command lines which were creating issues when being compiled as an extension
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dti_tract_stat&revision=131
