### PR TITLE
ENH: Addition of the extension ModelToModelDistance

### DIFF
--- a/ModelToModelDistance.s4ext
+++ b/ModelToModelDistance.s4ext
@@ -1,0 +1,44 @@
+#
+# First token of each non-comment line is the keyword and the rest of the line
+# (including spaces) is the value.
+# - the value can be blank
+#
+
+# This is source code manager (i.e. svn)
+scm git
+scmurl git://github.com/NIRALUser/3DMetricTools.git
+scmrevision 94da0eadb6147d3261527536f55aa2a68f0b0b53
+
+# list dependencies
+# - These should be names of other modules that have .s4ext files
+# - The dependencies will be built first
+depends     NA
+
+# Inner build directory (default is .)
+build_subdirectory .
+
+# homepage
+homepage    https://www.nitrc.org/projects/meshmetric3d/
+
+# Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
+# For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)
+contributors Francois Budin (UNC), Juliette Pera (UNC), Beatriz Paniagua (UNC)
+
+# Match category in the xml description of the module (where it shows up in Modules menu)
+category    Shape Analysis
+
+# url to icon (png, size 128x128 pixels)
+iconurl     http://slicer.org/slicerWiki/images/4/43/Slicer4ExtensionModelToModelDistance.png
+
+# Give people an idea what to expect from this code
+#  - Is it just a test or something you stand beind?
+status      
+
+# One line stating what the module does
+description This extension computes the distance between two 3D models
+
+# Space separated list of urls
+screenshoturls 
+
+# 0 or 1: Define if the extension should be enabled after its installation.
+enabled 1


### PR DESCRIPTION
This extension contains one CLI module of the same name. It computes a point by point distance between two models loaded in Slicer or VTK volumes. It is based on vtkDistancePolyDataFilter. The distance can be signed or unsigned.

More information can be found on the documentation page of the extension:
http://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/ModelToModelDistance

Or on the NITRC page of the project:
https://www.nitrc.org/projects/meshmetric3d/

The source code is available on github:
https://github.com/NIRALUser/3DMetricTools
