### PR TITLE
ENH: ModelToModelDistance matches 3DMeshMetric format in vtk files when ...

### DIFF
--- a/ModelToModelDistance.s4ext
+++ b/ModelToModelDistance.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl git://github.com/NIRALUser/3DMetricTools.git
-scmrevision 94da0eadb6147d3261527536f55aa2a68f0b0b53
+scmrevision 3f4a9be5b2cd4a36ac502a276a9a32d82c33dbd3
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files


### PR DESCRIPTION
...using VTK filter

-Scalar array is named "Distance" by the VTK filter "vtkDistancePolyDataFilter"
-Scalar array is renamed "Signed" if the computed is signed
-Scalar array is renamed "Absolute" if the computed distance is not signed
-An additional and constant field is added to the vtkPoyData and is called "Original"

https://github.com/NIRALUser/3DMetricTools/compare/96b73776c3e59328b5f45c8205021258cd3b93bf...3f4a9be5b2cd4a36ac502a276a9a32d82c33dbd3
