### PR TITLE
ENH: Updated DTIAtlasFiberAnalyzer from revision 131 to revision 137

### DIFF
--- a/DTIAtlasFiberAnalyzer.s4ext
+++ b/DTIAtlasFiberAnalyzer.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm svn
 scmurl https://www.nitrc.org/svn/dti_tract_stat/trunk/
-scmrevision 131
+scmrevision 137
 svnusername slicerbot
 svnpassword slicer
 


### PR DESCRIPTION
Creating release 1.5
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dti_tract_stat&revision=137
BUG: in fiberprocessing.cxx, 'ad' was refered as 'ad' instead of 'l1'
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dti_tract_stat&revision=136
BUG: Do not try to install fiberprocess if it is not build
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dti_tract_stat&revision=135
BUG: correct handling of data without ID column, detection of zipped vtk files (for no recompute)
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dti_tract_stat&revision=134
STYLE: remove debug messages
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dti_tract_stat&revision=133
BUG: Problem in variable name. It has one '_' too many install_dir was not always defined correctly
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dti_tract_stat&revision=132
