### PR TITLE
ENH: Add iGyne extension

### DIFF
--- a/iGyne.s4ext
+++ b/iGyne.s4ext
@@ -1,0 +1,13 @@
+build_subdirectory .
+category “IGT”
+contributors Guillaume Pernelle,  Alireza Mehrtash, Lauren Barber, Nabgha Fahrat, Jan Egger, Tobias Penzkofer, Sandy Wells, Sam Song, Xiaojun Chen, Yi Gao, Antonio Damato, Tina Kapur, Akila Viswanathan
+depends NA
+description iGyne is an open source software for MR-Guided Interstitial Gynecologic Brachytherapy. It enables on-time processing of the intra-operative MRI data via a DICOM connection to the scanner followed by a multi-stage registration of CAD models of the template and the obturator to the patient images. This allows the virtual placement of interstitial needles during the intervention, as well as the detection/labeling of needles in MR images
+enabled 1
+homepage https://github.com/gpernelle/iGyne
+iconurl https://raw.github.com/gpernelle/iGyne/master/iGyne.png
+scm git
+scmrevision 85d4aa39a68d523ead2f568cfcb0c0a89feef623
+scmurl https://github.com/gpernelle/iGyne.git
+screenshoturls http://www.slicer.org/slicerWiki/images/5/5d/IGyne-labelingResult.png
+status


### PR DESCRIPTION
Description:
iGyne is an open source software for MR-Guided Interstitial Gynecologic
Brachytherapy. It enables on-time processing of the intra-operative MRI
data via a DICOM connection to the scanner followed by a multi-stage
registration of CAD models of the template and the obturator to the
patient images. This allows the virtual placement of interstitial
needles during the intervention, as well as the detection/labeling of
needles in MR images

Contributors:
Guillaume Pernelle,  Alireza Mehrtash, Lauren Barber, Nabgha Fahrat, Jan
Egger, Tobias Penzkofer, Sandy Wells, Sam Song, Xiaojun Chen, Yi Gao,
Antonio Damato, Tina Kapur, Akila Viswanathan
