### PR TITLE
ENH: Add NeedleFinder extension

### DIFF
--- a/NeedleFinder.s4ext
+++ b/NeedleFinder.s4ext
@@ -1,0 +1,13 @@
+build_subdirectory .
+category IGT
+contributors Guillaume Pernelle,  Alireza Mehrtash, Lauren Barber, Nabgha Fahrat, Jan Egger, Tobias Penzkofer, Sandy Wells, Sam Song, Xiaojun Chen, Yi Gao, Antonio Damato, Tina Kapur, Akila Viswanathan
+depends NA
+description NeedleFinder: fast interactive needle detection. It is an open source software for MR-Guided Interstitial Gynecologic Brachytherapy. It enables on-time processing of the intra-operative MRI data via a DICOM connection to the scanner followed by a multi-stage registration of CAD models of the template and the obturator to the patient images. This allows the virtual placement of interstitial needles during the intervention, as well as the detection/labeling of needles in MR images
+enabled 1
+homepage https://github.com/gpernelle/NeedleFinder
+iconurl https://raw.github.com/gpernelle/NeedleFinder/master/NeedleFinder.png
+scm git
+scmrevision 104d82ee1330a9f2133acdf544d8dfa30f6e150a
+scmurl https://github.com/gpernelle/NeedleFinder.git
+screenshoturls https://raw.github.com/gpernelle/NeedleFinder/master/LabelingResult.png
+status


### PR DESCRIPTION
Description:
NeedleFinder: fast interactive needle detection. It is an open source
software for MR-Guided Interstitial Gynecologic Brachytherapy. It
enables on-time processing of the intra-operative MRI data via a DICOM
connection to the scanner followed by a multi-stage registration of CAD
models of the template and the obturator to the patient images. This
allows the virtual placement of interstitial needles during the
intervention, as well as the detection/labeling of needles in MR images

Contributors:
Guillaume Pernelle,  Alireza Mehrtash, Lauren Barber, Nabgha Fahrat, Jan
Egger, Tobias Penzkofer, Sandy Wells, Sam Song, Xiaojun Chen, Yi Gao,
Antonio Damato, Tina Kapur, Akila Viswanathan
