### PR TITLE
ENH: Update DTIPrep from r240 to r296

### DIFF
--- a/DTIPrep.s4ext
+++ b/DTIPrep.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm svn
 scmurl https://www.nitrc.org/svn/dtiprep/trunk
-scmrevision 295
+scmrevision 296
 svnusername slicerbot
 svnpassword slicer
 


### PR DESCRIPTION
http://www.nitrc.org/plugins/scmsvn/viewcvs.php/trunk/?root=dtiprep&view=log

r296:
BUG: Missing file
r295:
Update Superbuild process to build DTIPrep on Windows (Slicer4 extension)
r294:
COMP: Need to include SlicerExecutionModel before Common.cmake
r293:
COMP:  vtkVersion.h is required for both vtk6 and vtk5
r292:
BUG: New version of BRAINSTools depend on VTK. The dependency has been added to the External_BRAINSTools.cmake file
ENH: niral_utilities has been updated to latest version
r291:
BUG: Compilation issues with VTK 6. Some files were missing preprocessor tests include VTK5 or VTK6 header files
ENH: BRAINSTools has been updated ot latest available version
r290:
COMP: VTK 6 compatibility fixes
r289:
ENH: Update to latest ITKv4 that uses new registration framework.
r288:
COMP: fixed issues related to compiling with VTK 6.1
COMP: UtilRegister.h didn't match current API for BRAINSFitHelper.
r287:
COMP: C++11 compiler identified error
r285:
ENH: Addition of an option to select the number of threads used by multithreaded ITK filters. By default the option is set to 3.
     New version number: 1.2.4
r281:
ENH: DTIPrep saves EddyMotion transforms in xml file
r280:
ENH: When selecting "default protocol", it will search for the software on the system instead of setting paths to hardcoded paths for the tools that are available in "Protocol Path". This still needs to be improved for the other tools which paths are hardcoded in the default protocol such as LMMSE that is included in Slicer3"
r279:
ENH: Replacing default value of DicomToNrrdConverter tool byt DWIConvert
r278:
BUG: SlicerExecutionModel_DEFAULT_CLI_INSTALL_RUNTIME_DESTINATION is only defined on Mac when creating an extension. Instead, we use Slicer_INSTALL_CLIMODULES_BIN_DIR which is defined on all platforms
r277:
COMP: Remove unused variable warning.
r276:
BUG: Update CMakeLists to make compilation and packaging work on MacOS
r275:
ENH: Scalar images were rescaled and saved as integer images. Addition of the option "--scalar_float" to save these images as float
ENH: Refactorization of the code when searching for a program
r274:
ENH: Saves recomputed image.\nBUG: Removes svn:externals of https://www.nitrc.org/svn/brains/BuildScripts/trunk
r273:
ENH: Installation for tools when not build as extension
r272:
BUG: When trying to set where a tool was on the system (ie: bet), the qFiledialog was filtering with the wrong filter and was not letting the user select any file
BUG: The box presenting the options to select the interpolation method was entitled "interpolation method for baseline computation" even when selecting the interpolation method to during Eddy motion correction
r271:
ENH: DTIPrep version number updated
ENH: Choice of method to compute baseline average is now limited to 2 methods
r270:
ENH: Addition of the interpolation method choice for average computation with BaselineOptimizedAverage
r269:
ENH: Addition of the choice of the interpolation method used when performing Eddy motion correction
r268:
ENH: Addition of an option to choose the interpolation method used to compute the average baseline image
r267:
ENH: DTIProcess is now build automatically if DTIPrep is built as an extension
ENH: Addition of default directories for DTIPrep to look for the external tools
r266:
BUG: DUSE_BRAINSABC was set to 'OF' instead of 'OFF'
r265:
BUG: Version number in xml file had not been changed
r264:
ENH: Mask computation from the IDWI with bet2
ENH: Auto completion of the tools path in "Protocol Path" if a protocol xml is loaded and contains those paths
CLEAN: Remove the usage of convertITKformats from the mask computation with bet2 because it was not necessary
ENH: When loading an xml protocol file, it always sends a SIGNAL warning that the protocol was changed, and not only when one of the 3 possible button to load a protocol is pushed
CLEAN: Addition of spaces between words in error messages printed out
r263:
COMP: fix CMake syntax to silence CMake warning.
r262:
BUG: correct removal of Entropy temp data
r261:
ENH: brainmask error handling
r260:
BUG: I tried to untangle the InensityMotionCheck error reporting
r259:
BUG: integer return values stored in bool.
r258:
COMP: fix handling of system zlib
r257:
COMP: tell svn to ignore SuperBuild/ExternalSources Directory
r256:
COMP: Synchronized with NamicExternalProjects build system
r255:
COMP: Cleaned up importing ANTs stuff for BRAINSTools
r254:
COMP: fix up External_DCMTK.cmake
r253:
STYLE: correct indentation
COMP: Fix CMAKE_BUILD_TYPE name
r252:
ENH: BRAINSTools to include fixed version of UKF.
ENH: Update BRAINSTools with BCD fixes.
r251:
BUG: Debugging DTIPrep returning non-zero status even when successful.
r250:
BUG: Bug in DTIProcess required update.
r249:
COMP: Ensure that all sub-packages are updated to latest version
r248:
COMP: Remove warning about trigraphs caused by ill formed comment
r247:
COMP: UKF via BRAINSTools had bugs that needed resolving in the build process.
r246:
COMP: Syncronized and fixed bug in DCMTK path finding
r245:
STYLE: Useless ITK deprecated define removed
r244:
BUG: Path to executables was found only after reconfiguring the project
r243:
BUG: Builds DCMTK in SuperBuild_DTIPrep before adding BRAINSTools
r242:
COMP: Fixed error in DCMTK pathing
r241:
ENH: Update ITK and BRAINSTools
