### PR TITLE
ENH: Update DTIPrep from r296 to r297

### DIFF
--- a/DTIPrep.s4ext
+++ b/DTIPrep.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm svn
 scmurl https://www.nitrc.org/svn/dtiprep/trunk
-scmrevision 296
+scmrevision 297
 svnusername slicerbot
 svnpassword slicer
 


### PR DESCRIPTION
-Remove unused Mac installation files
-Does not build ITK_Module_MGHIO when DTIPrep is built as a Slicer extension to avoid conflicts
