### PR TITLE
ENH: Update DTIAtlasFiberAnalyzer from r137 to r140

### DIFF
--- a/DTIAtlasFiberAnalyzer.s4ext
+++ b/DTIAtlasFiberAnalyzer.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm svn
 scmurl https://www.nitrc.org/svn/dti_tract_stat/trunk/
-scmrevision 137
+scmrevision 140
 svnusername slicerbot
 svnpassword slicer
 


### PR DESCRIPTION
r140:
ENH: DTIAtlasFiberAnalyzer looks for tools in current executable directory as well as in directories where executables are expected to be found in the case it is part of a Slicer extension.
ENH: Warnings corrected
ENH: fiberprocess is now packaged in cli-modules/../ExternalBin to avoid conflicts with fiberprocess that is part of the DTIProcess extension

r139:
BUG: Committing dtitractstat files that should have been committed at rev138

r138:
ENH: dtitractstat has a new flag to remove clean fibers (which are automatically saved on the hard drive by design)
DTIAtlasFiberAnalyzer has an option to keep or remove the clean fibers that are automatically computed by dtitractstat. By default, those files are removed.
