### PR TITLE
ENH: Update NeedleFinder extension

### DIFF
--- a/NeedleFinder.s4ext
+++ b/NeedleFinder.s4ext
@@ -7,7 +7,7 @@ enabled 1
 homepage https://github.com/gpernelle/NeedleFinder
 iconurl https://raw.github.com/gpernelle/NeedleFinder/master/NeedleFinder.png
 scm git
-scmrevision 216798f85ed6a94c8711571c4512cef50e42c69e
+scmrevision 341b3b9d00c8091c9c4f63ff4121acbe269551d6
 scmurl https://github.com/gpernelle/NeedleFinder.git
 screenshoturls https://raw.github.com/gpernelle/NeedleFinder/master/screenshot.png
 status


### PR DESCRIPTION
This updates the NeedleFinder extension to https://github.com/gpernelle/ExtensionsIndex/commit/c643e569cb034234bea9037fcae1c23bbfcd2219.
