### PR TITLE
ENH: Update DTIProcess from revision 214 to revision 222.  Builds with V...

### DIFF
--- a/DTIProcess.s4ext
+++ b/DTIProcess.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm svn
 scmurl https://www.nitrc.org/svn/dtiprocess/trunk
-scmrevision 214
+scmrevision 222
 svnusername slicerbot
 svnpassword slicer
 
@@ -20,7 +20,7 @@ depends     NA
 build_subdirectory DTIProcess-build
 
 # homepage
-homepage    http://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/DTIProcess
+homepage    http://www.nitrc.org/projects/dtiprocess
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
 # For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)
@@ -30,7 +30,7 @@ contributors Francois Budin (UNC)
 category    Diffusion
 
 # url to icon (png, size 128x128 pixels)
-iconurl     http://www.nitrc.org/project/screenshot.php?group_id=312&screenshot_id=575
+iconurl    http://www.nitrc.org/project/screenshot.php?group_id=312&screenshot_id=771
 
 # Give people an idea what to expect from this code
 #  - Is it just a test or something you stand beind?


### PR DESCRIPTION
...TK6 and has a new icon.

r222: http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dtiprocess&revision=222
ENH: Change "homepage" and icon for DTIProcess built as a Slicer extension

r221: http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dtiprocess&revision=221
ENH: Update VTK6 build to match more closely the way it is done in Slicer, setting a string to choose the version of VTK instead of using a boolean.

r220: http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dtiprocess&revision=220
ENH: Updated Superbuild and DTIProcess can build against VTK6

r219: http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dtiprocess&revision=219
COMP: remove obsolete boost command line processing code

r218: http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dtiprocess&revision=218
COMP: backward compat to vtk5

r217: http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dtiprocess&revision=217
COMP: vtk6 changes

r216: http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dtiprocess&revision=216
COMP: made changes to be compatible with VTK 6

r215: http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dtiprocess&revision=215
ENH: Removed install rules that were duplicated in the Applications directory
