### PR TITLE
A new module is added to the Scoliosis extension.

### DIFF
--- a/Scoliosis.s4ext
+++ b/Scoliosis.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm svn
 scmurl https://subversion.assembla.com/svn/Scoliosis/trunk/Scoliosis/src
-scmrevision 12
+scmrevision 51
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files


### PR DESCRIPTION
A new module was added to the scoliosis extension. With this module it is possible to compute the transverse process angles using tracked ultrasound snapshots and also sequences acquired using PLUS and OpenIGTLink. This module uses SlicerIGT extension and also the Multidimensional Data extension.
Detailed explanation of the purpose of the module including the user guide can be found in:
https://www.assembla.com/spaces/Scoliosis/wiki/Scoliosis_Monitoring_slicelet
This commit is associated with revision 51:
https://www.assembla.com/code/Scoliosis/subversion/commit/51
