### PR TITLE
ENH: Add PercutaneousApproachAnalysis extension

### DIFF
--- a/PercutaneousApproachAnalysis.s4ext
+++ b/PercutaneousApproachAnalysis.s4ext
@@ -1,0 +1,13 @@
+build_subdirectory .
+category IGT
+contributors Koichiro Murakami (Shiga University of Medical Science, Japan, SPL), Laurent Chauvin (SPL), Junichi Tokuda (SPL)
+depends NA
+description The Percutaneous Approach Analysis is used to calculate and visualize the accessibility of liver tumor with a percutaneous approach.
+enabled 1
+homepage http://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/PercutaneousApproachAnalysis
+iconurl http://www.slicer.org/slicerWiki/images/a/ac/PAAlogo-small.png
+scm git
+scmrevision 773e8ace5aa1fd32a80550980ec452608bb6162a
+scmurl https://github.com/SNRLab/PercutaneousApproachAnalysis.git
+screenshoturls http://www.slicer.org/slicerWiki/images/4/42/Accessibility_clinical.png
+status


### PR DESCRIPTION
Description:
The Percutaneous Approach Analysis is used to calculate and visualize
the accessibility of liver tumor with a percutaneous approach.

Contributors:
Koichiro Murakami (Shiga University of Medical Science, Japan, SPL),
Laurent Chauvin (SPL), Junichi Tokuda (SPL)
