### PR TITLE
ENH: Update SPHARM-PDM from r216 to r228

### DIFF
--- a/SPHARM-PDM.s4ext
+++ b/SPHARM-PDM.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm svn
 scmurl https://www.nitrc.org/svn/spharm-pdm
-scmrevision 216
+scmrevision 228
 svnusername slicerbot
 svnpassword slicer
 


### PR DESCRIPTION
r228: ENH: Moving CMake Slicer extension variables to top level CMakeLists.txt file
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=spharm-pdm&revision=228

r227: BUG: Missing argument definition scaleOn
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=spharm-pdm&revision=227

r226: BUG: CMAKE_BUILD_TYPE does not exist on Windows
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=spharm-pdm&revision=226

r225: BUG: zlib is not required
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=spharm-pdm&revision=225

r224: BUG: #include was missing in many files to be able to compile SPHARM-PDM with VTK6
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=spharm-pdm&revision=224

r223: ENH: rescaleOn option added to ShapeAnalysisModule
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=spharm-pdm&revision=223

r222: ENH: rescaleOn option added to ShapeAnalysisModule
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=spharm-pdm&revision=222

r221: ENH: rescaleOn option added to ShapeAnalysisModule
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=spharm-pdm&revision=221

r220: ENH: rescaleOn option added to ShapeAnalysisModule
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=spharm-pdm&revision=220

r219: BUG: With gcc4.8.2 (Ubuntu 14.04), libblas.a and liblapack.a were not found. We added their relative path from ${CLAPACK_DIR} to link_directories() so that they are found correctly
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=spharm-pdm&revision=219

r218: ENH: Compiles with VTK6
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=spharm-pdm&revision=218

r217: ENH: Builds with VTK6
http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=spharm-pdm&revision=217
