### PR TITLE
ENH: Add CardiacAgastonMeasures extension

### DIFF
--- a/CardiacAgastonMeasures.s4ext
+++ b/CardiacAgastonMeasures.s4ext
@@ -1,0 +1,13 @@
+build_subdirectory .
+category Cardiac
+contributors Jessica Forbes (UIowa), Hans Johnson (UIowa)
+depends NA
+description This module will auto-segment the coronary calcium in Cardiac CT scans and then calculate the Agatston score and label statistics
+enabled 1
+homepage http://brainsia.github.io/CardiacAgatstonMeasures/
+iconurl http://www.na-mic.org/Wiki/images/b/b5/CardiacAgatstonModuleIamge.png
+scm git
+scmrevision 2bbc87c3aa7bc28288eedfe390ca6a344b1914de
+scmurl git://github.com/BRAINSia/CardiacAgatstonMeasures.git
+screenshoturls http://www.na-mic.org/Wiki/images/6/63/CardiacAgatstonMeasuresModuleScreenshot.jpg
+status


### PR DESCRIPTION
Description:
This module will auto-segment the coronary calcium in Cardiac CT scans
and then calculate the Agatston score and label statistics

Contributors:
Jessica Forbes (UIowa), Hans Johnson (UIowa)
