### PR TITLE
ENH: The new name for the mesh  extension

### DIFF
--- a/CBC3DI2MConversion.s4ext
+++ b/CBC3DI2MConversion.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl git://github.com/fdrakopo/ImageToMeshConversion.git
-scmrevision 2c39a67
+scmrevision 9c8e63d
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files
@@ -18,7 +18,7 @@ depends     NA
 build_subdirectory .
 
 # homepage
-homepage    http://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/ImageToMeshConversion
+homepage    http://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/CBC3DI2MConversion
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
 # For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)
@@ -35,7 +35,7 @@ iconurl     http://wiki.slicer.org/slicerWiki/images/3/3e/I2M_logo.jpg
 status      
 
 # One line stating what the module does
-description Image-To-Mesh Conversion (I2M) for Image Guided Therapy. The extension encapsulates two CLI modules: (1) Body Centric Cubic (BCC) Mesh Generation. This module generates a Body Centric Cubic (BCC) mesh from a labeled image. Initially the generated mesh is homogeneous, that means does not distinguish different tissues. Later the component specifies which tissue each tetrahedron belongs to. Each tissue is capable of automatically adjusting its resolution based on its geometric complexity and the predefined subdivision criterion. (2) Mesh Compression (MC). This module deforms an input tetrahedral mesh towards the boundaries of the input labeled image. Two point sets are extracted for the mesh deformation. The first (source point set) consists of the surface vertices of the input mesh. The second (target point set) consists of the surface edge points in the input labeled image. Then the input mesh is deformed by registering the source to the target point set using a Physics-Based Non-Rigid Registration method.
+description CBC 3D (CRTC's BCC & Compression) I2M (Image-To-Mesh) Conversion for Image Guided Therapy. The extension encapsulates two CLI modules: (1) Body Centric Cubic (BCC) Mesh Generation. This module generates a Body Centric Cubic (BCC) mesh from a labeled image. Initially the generated mesh is homogeneous, that means does not distinguish different tissues. Later the component specifies which tissue each tetrahedron belongs to. Each tissue is capable of automatically adjusting its resolution based on its geometric complexity and the predefined subdivision criterion. (2) Mesh Compression (MC). This module deforms an input tetrahedral mesh towards the boundaries of the input labeled image. Two point sets are extracted for the mesh deformation. The first (source point set) consists of the surface vertices of the input mesh. The second (target point set) consists of the surface edge points in the input labeled image. Then the input mesh is deformed by registering the source to the target point set using a Physics-Based Non-Rigid Registration method.
 
 # Space separated list of urls
 screenshoturls http://www.slicer.org/slicerWiki/images/e/ea/Brain_before.jpg http://www.slicer.org/slicerWiki/images/b/b4/Brain_after.jpg http://www.slicer.org/slicerWiki/images/f/f3/Brain_after_section.jpg http://www.slicer.org/slicerWiki/images/5/54/Ventricles_before.jpg http://www.slicer.org/slicerWiki/images/3/31/Ventricles_after.jpg http://www.slicer.org/slicerWiki/images/7/7c/Ventricles_after_section.jpg


### PR DESCRIPTION
This commit replaces the old extension's name with a new one and changes the url for the documentation. Also fixes a windows build error.
