### PR TITLE
COMP: Address a windows compilation error

### DIFF
--- a/CBC_3D_I2MConversion.s4ext
+++ b/CBC_3D_I2MConversion.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl git://github.com/fdrakopo/ImageToMeshConversion.git
-scmrevision 5b8acb0
+scmrevision 1f490c6
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files


### PR DESCRIPTION
fmin was replaced by std::min to address the windows compilation error
