### PR TITLE
ENH: Update DTIProcess from rev222 to r224

### DIFF
--- a/DTIProcess.s4ext
+++ b/DTIProcess.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm svn
 scmurl https://www.nitrc.org/svn/dtiprocess/trunk
-scmrevision 222
+scmrevision 224
 svnusername slicerbot
 svnpassword slicer
 


### PR DESCRIPTION
https://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dtiprocess&revision=224

ENH: Addition of a License.txt and a README.txt file
ENH: Applications are now under new sections in Slicer:
-dtiestim now appears as "DTIEstim (DTIProcess)" in the "Diffusion/Diffusion Weighted Images" section
-dtiprocess now appears as "DTIProcess (DTIProcess)" in the "Diffusion/Diffusion Tensor Images" section
-fiberprocess now appears as "FiberProcess (DTIProcess)" in the "Diffusion/Tractography" section
-dtiaverage now appears as "DTIAverage (DTIProcess)" in the "Diffusion/Diffusion TensorImages/CommandLineOnly" section
-fiberstats now appears as "FiberStats (DTIProcess)" in the "Diffusion/Tractography/CommandLineOnly" section
-fibertrack now appears as "FiberTrack (DTIProcess)" in the "Diffusion/Tractography" section
-maxcurvature now appears as "MaxCurvature-Hessian (DTIProcess)" in the "Diffusion" section
-scalartransform now appears as "ScalarTransform (DTIProcess)" in the "Legacy/Registration" section
ENH: scalartransform, fibertrack as well as maxcurvature are not packaged anymore as part of the DTIProcess Slicer extension
