### PR TITLE
ENH: Addition of IntensitySegmenter as a Slicer extension

### DIFF
--- a/IntensitySegmenter.s4ext
+++ b/IntensitySegmenter.s4ext
@@ -1,0 +1,46 @@
+#
+# First token of each non-comment line is the keyword and the rest of the line
+# (including spaces) is the value.
+# - the value can be blank
+#
+
+# This is source code manager (i.e. svn)
+scm svn
+scmurl https://www.nitrc.org/svn/dentaltools/Applications/IntensitySegmenter/
+scmrevision 10
+svnusername slicerbot
+svnpassword slicer
+
+# list dependencies
+# - These should be names of other modules that have .s4ext files
+# - The dependencies will be built first
+depends     NA
+
+# Inner build directory (default is .)
+build_subdirectory .
+
+# homepage
+homepage   http://www.nitrc.org/projects/dentaltools/
+
+# Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
+# For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)
+contributors Pengdong Xiao (Department of Orthodontics, UNC), Beatriz Paniagua (Department of Orthodontics, UNC), Francois Budin (NIRAL, UNC)
+
+# Match category in the xml description of the module (where it shows up in Modules menu)
+category    Segmentation
+
+# url to icon (png, size 128x128 pixels)
+iconurl     http://wiki.slicer.org/slicerWiki/images/f/f6/IntensitySegmenterIcon.png
+
+# Give people an idea what to expect from this code
+#  - Is it just a test or something you stand beind?
+status  beta  
+
+# One line stating what the module does
+description IntensitySegmenter is a simple tool that segments an image according to intensity value. It is mainly used to segment CT scans using the Hounsfield scale but the ranges of intensities and their corresponding labels can be specified in an input text file. 
+
+# Space separated list of urls
+screenshoturls http://wiki.slicer.org/slicerWiki/images/7/7c/IntensitySegmenter-OutputScreenshot.png
+
+# 0 or 1: Define if the extension should be enabled after its installation.
+enabled 1


### PR DESCRIPTION
IntensitySegmenter is a simple tool that segments an image according to intensity value. It is mainly used to segment CT scans using the Hounsfield scale but the ranges of intensities and their corresponding labels can be specified in an input text file. For more information, refer to [1] and [2]

[1] http://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/IntensitySegmenter
[2] http://www.nitrc.org/projects/dentaltools/
