### PR TITLE
ENH: Allow to configure with CMake 2.8.10

### DIFF
--- a/IntensitySegmenter.s4ext
+++ b/IntensitySegmenter.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm svn
 scmurl https://www.nitrc.org/svn/dentaltools/Applications/IntensitySegmenter/
-scmrevision 10
+scmrevision 11
 svnusername slicerbot
 svnpassword slicer
 


### PR DESCRIPTION
In previous revision, IntensitySegmenter could only be configured with CMake 2.8.12 and above. This was because "ExternalData" and "ExternalData_Add_Test" only exist starting in CMake 2.8.11 and CMake 2.8.12 is already widely used. However, CMake 2.8.10 is still used to compile Slicer extensions for Windows and Linux.

http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dentaltools&revision=11
