### PR TITLE
ENH: Update IntensitySegmenter from r11 to r12

### DIFF
--- a/IntensitySegmenter.s4ext
+++ b/IntensitySegmenter.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm svn
 scmurl https://www.nitrc.org/svn/dentaltools/Applications/IntensitySegmenter/
-scmrevision 11
+scmrevision 12
 svnusername slicerbot
 svnpassword slicer
 


### PR DESCRIPTION
ENH: Changed IntensitySegmenter CLI category in Slicer
ENH: The input image is loaded as a float image. This allows to use float ranges.
ENH: Addition of a default voxel value in case the range does not cover this value
ENH: Addition of tests to cover more options

http://www.nitrc.org/plugins/scmsvn/viewcvs.php?root=dentaltools&view=rev
