### PR TITLE
Update PerkTutor extension. Add PythonMetricsCalculator module for computing all motion economy metrics.

### DIFF
--- a/PerkTutor.s4ext
+++ b/PerkTutor.s4ext
@@ -7,14 +7,14 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl https://github.com/PerkTutor/PerkTutor.git
-scmrevision 185ce96
+scmrevision ed73de6
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files
 # - The dependencies will be built first
 depends     NA
 
-# Inner build directory (default is .)
+# Inner build directory (default is ".")
 build_subdirectory inner-build
 
 # homepage
@@ -31,7 +31,7 @@ category    Training
 iconurl     http://www.slicer.org/slicerWiki/images/2/21/PerkTutorLogo.png
 
 # Give people an idea what to expect from this code
-#  - Is it just a test or something you stand beind?
+#  - Is it just a test or something you stand behind?
 status      
 
 # One line stating what the module does


### PR DESCRIPTION
Compare link for superbuild: https://github.com/PerkTutor/PerkTutor/compare/185ce96d1eb04bc3b8393b0e2524d82ce99921bd...ed73de64166ac306a19a40bb825fc4956dd578bd.

PythonMetricsCalculator module repository: https://github.com/PerkTutor/PythonMetricsCalculator.git.
