### PR TITLE
Add PETDICOMExtension

### DIFF
--- a/PETDICOMExtension.s4ext
+++ b/PETDICOMExtension.s4ext
@@ -1,0 +1,44 @@
+#
+# First token of each non-comment line is the keyword and the rest of the line
+# (including spaces) is the value.
+# - the value can be blank
+#
+
+# This is source code manager (i.e. svn)
+scm git
+scmurl https://github.com/QIICR/Slicer-PETDICOMExtension.git
+scmrevision 587fab8
+
+# list dependencies
+# - These should be names of other modules that have .s4ext files
+# - The dependencies will be built first
+depends     NA
+
+# Inner build directory (default is ".")
+build_subdirectory .
+
+# homepage
+homepage    http://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/PETDICOM
+
+# Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
+# For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)
+contributors Ethan Ulrich (University of Iowa), Andrey Fedorov (BWH, SPL)
+
+# Match category in the xml description of the module (where it shows up in Modules menu)
+category    Converters
+
+# url to icon (png, size 128x128 pixels)
+iconurl     https://raw.githubusercontent.com/QIICR/Slicer-PETDICOMExtension/master/PETDICOMExtension.png
+
+# Give people an idea what to expect from this code
+#  - Is it just a test or something you stand behind?
+status      
+
+# One line stating what the module does
+description The PET DICOM Extension provides tools to import PET Standardized Uptake Value images from DICOM into Slicer.
+
+# Space separated list of urls
+screenshoturls http://wiki.slicer.org/slicerWiki/images/thumb/2/2e/SUV_Factor_Calculator_GUI.png/418px-SUV_Factor_Calculator_GUI.png http://wiki.slicer.org/slicerWiki/images/thumb/2/29/DICOM_Browser_RWVM_Plugin.png/800px-DICOM_Browser_RWVM_Plugin.png http://wiki.slicer.org/slicerWiki/images/thumb/4/43/DICOM_Browser_PET_SUV_Plugin.png/800px-DICOM_Browser_PET_SUV_Plugin.png
+
+# 0 or 1: Define if the extension should be enabled after its installation.
+enabled 1


### PR DESCRIPTION
The PET DICOM Extension provides tools to import PET Standardized Uptake Value images from DICOM into Slicer:
*SUV Factor Calculator CLI - takes a PET DICOM series and creates a Real World Value Mapping (RWVM) file including 4 types of Standardized Uptake Value conversion factors (SUVbw, SUVlbm, SUVbsa, SUVibw).
*DICOM RWVM Plugin - extends the DICOM module to support parsing and loading of DICOM series associated with Real World Value Mapping (RWVM) objects.
*DICOM PET SUV Plugin - extends the DICOM module to support parsing and loading of PET DICOM series as Standardized Uptake Value (SUV) images.
