### PR TITLE
Updated VolumeClip - fixed extension path

### DIFF
--- a/VolumeClip.s4ext
+++ b/VolumeClip.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm svn
 scmurl https://subversion.assembla.com/svn/slicerrt/trunk/VolumeClip/src
-scmrevision 1988
+scmrevision 1989
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files


### PR DESCRIPTION
Automatically generated revision number was incorrect, as the parent directory was modified in rev 1989 and therefore the s4ext generator script missed this latest revision.
