### PR TITLE
ENH: Update IntensitySegmenter from r12 to r13

### DIFF
--- a/IntensitySegmenter.s4ext
+++ b/IntensitySegmenter.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm svn
 scmurl https://www.nitrc.org/svn/dentaltools/Applications/IntensitySegmenter/
-scmrevision 12
+scmrevision 13
 svnusername slicerbot
 svnpassword slicer
 


### PR DESCRIPTION
BUG: include(ExternalData) was missing.

Project was not configuring with CMake 2.8*, but only with CMake 3. Inclusion of CTest and ExternalData has been moved to main CMakeLists (not superbuild) to be able to run the tests from the main folder.

http://www.nitrc.org/plugins/scmsvn/viewcvs.php?view=rev&root=dentaltools&revision=13
