### PR TITLE
update LongitudinalPETCT for 4.4

### DIFF
--- a/LongitudinalPETCT.s4ext
+++ b/LongitudinalPETCT.s4ext
@@ -6,8 +6,8 @@
 
 # This is source code manager (i.e. svn)
 scm git
-scmurl https://github.com/paulcm/LongitudinalPETCT
-scmrevision 37dff73
+scmurl https://github.com/QIICR/LongitudinalPETCT
+scmrevision 88338b9b4
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files


### PR DESCRIPTION
Fix issues related to VTK6 API changes

Note: Source code is now checked out from QIICR repository, as the original
developer (Paul Mercea) is unavailable to support this extension (not responsive
to emails).
