### PR TITLE
ENH: Adding new extension MeshToLabelMap

### DIFF
--- a/MeshToLabelMap.s4ext
+++ b/MeshToLabelMap.s4ext
@@ -1,0 +1,44 @@
+#
+# First token of each non-comment line is the keyword and the rest of the line
+# (including spaces) is the value.
+# - the value can be blank
+#
+
+# This is source code manager (i.e. svn)
+scm git
+scmurl https://github.com/NIRALUser/MeshToLabelMap.git
+scmrevision b20c79e853ca40f00b3130b4f288518299cde30d
+
+# list dependencies
+# - These should be names of other modules that have .s4ext files
+# - The dependencies will be built first
+depends     NA
+
+# Inner build directory (default is .)
+build_subdirectory .
+
+# homepage
+homepage   http://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/MeshToLabelMap
+
+# Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
+# For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)
+contributors Francois Budin (UNC)
+
+# Match category in the xml description of the module (where it shows up in Modules menu)
+category    Shape Analysis
+
+# url to icon (png, size 128x128 pixels)
+iconurl    https://raw.githubusercontent.com/NIRALUser/MeshToLabelMap/master/icons/MeshToLabelMapIcon128x128.png
+
+# Give people an idea what to expect from this code
+#  - Is it just a test or something you stand beind?
+status   Release
+
+# One line stating what the module does
+description This extension computes a label map from a 3D model
+
+# Space separated list of urls
+screenshoturls http://slicer.org/slicerWiki/images/thumb/5/54/MeshToLabelMapScreenshot.png/800px-MeshToLabelMapScreenshot.png
+
+# 0 or 1: Define if the extension should be enabled after its installation.
+enabled 1


### PR DESCRIPTION
MeshToLabelMap computes a label map from a model. Slicer contains a module called "Model to labelmap" module that performs the same operation but that has some limitations due to the asumptions it makes. For more information about the available (and upcoming) modules to perform a model to label map conversion, see discussion [1].

[1] http://massmail.spl.harvard.edu/public-archives/slicer-devel/2014/016831.html
