### PR TITLE
Add PETTumorSegmentation

### DIFF
--- a/PETTumorSegmentation.s4ext
+++ b/PETTumorSegmentation.s4ext
@@ -1,0 +1,44 @@
+#
+# First token of each non-comment line is the keyword and the rest of the line
+# (including spaces) is the value.
+# - the value can be blank
+#
+
+# This is source code manager (i.e. svn)
+scm git
+scmurl https://github.com/chribaue/PETTumorSegmentation.git
+scmrevision 5f508c11eb18c712fd968f0de300e924e6c5ac1f
+
+# list dependencies
+# - These should be names of other modules that have .s4ext files
+# - The dependencies will be built first
+depends     NA
+
+# Inner build directory (default is ".")
+build_subdirectory .
+
+# homepage
+homepage    http://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/PETTumorSegmentation
+
+# Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
+# For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)
+contributors Christian Bauer (University of Iowa), Markus van Tol (University of Iowa)
+
+# Match category in the xml description of the module (where it shows up in Modules menu)
+category    Editor Effects
+
+# url to icon (png, size 128x128 pixels)
+iconurl     https://raw.githubusercontent.com/chribaue/PETTumorSegmentation/master/PETTumorSegmentation.png
+
+# Give people an idea what to expect from this code
+#  - Is it just a test or something you stand behind?
+status      
+
+# One line stating what the module does
+description The PET DICOM Extension provides tools to import PET Standardized Uptake Value images from DICOM into Slicer.
+
+# Space separated list of urls
+screenshotutls https://http://www.slicer.org/slicerWiki/images/0/04/PETTumorSegmentation_Effect_with_models.png https://http://www.slicer.org/slicerWiki/images/9/97/PETTumorSegmentationEffect_options.png
+
+# 0 or 1: Define if the extension should be enabled after its installation.
+enabled 1


### PR DESCRIPTION
This extension allows segmetation of tumors and hot lymph nodes in PET scans. It is implemented as an Editor Effect.
Documentation is available at:
http://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/PETTumorSegmentation