### PR TITLE
BUG: Fixed MultidimData build error

### DIFF
--- a/MultidimData.s4ext
+++ b/MultidimData.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm svn
 scmurl https://subversion.assembla.com/svn/slicerrt/trunk/MultidimData/src
-scmrevision 1980
+scmrevision 2140
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files


### PR DESCRIPTION
These errors recently showed up on the dsahboard: error: no viable conversion from 'QByteArray' to 'const std::string' (aka 'const basic_string')
This pull request should fix this problem.