### PR TITLE
ENH: Add DeveloperToolsForExtensions

### DIFF
--- a/DeveloperToolsForExtensions.s4ext
+++ b/DeveloperToolsForExtensions.s4ext
@@ -1,0 +1,44 @@
+#
+# First token of each non-comment line is the keyword and the rest of the line
+# (including spaces) is the value.
+# - the value can be blank
+#
+
+# This is source code manager (i.e. svn)
+scm git
+scmurl git://github.com/fbudin69500/SlicerDeveloperToolsForExtensions.git
+scmrevision 2620612
+
+# list dependencies
+# - These should be names of other modules that have .s4ext files
+# - The dependencies will be built first
+depends     NA
+
+# Inner build directory (default is ".")
+build_subdirectory .
+
+# homepage
+homepage    http://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/DeveloperToolsForExtensions
+
+# Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
+# For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)
+contributors Francois Budin (UNC)
+
+# Match category in the xml description of the module (where it shows up in Modules menu)
+category    Developer Tools
+
+# url to icon (png, size 128x128 pixels)
+iconurl     https://raw.githubusercontent.com/fbudin69500/SlicerDeveloperToolsForExtensions/master/DeveloperToolsForExtensions/Resources/Icons/DeveloperToolsForExtensions.png
+
+# Give people an idea what to expect from this code
+#  - Is it just a test or something you stand behind?
+status      
+
+# One line stating what the module does
+description This extension offers different tools to help developers when they create Slicer extension.
+
+# Space separated list of urls
+screenshoturls http://www.slicer.org/slicerWiki/images/5/54/SlicerExtension-SlicerDeveloperToolsForExtensions-Screenshot.png http://www.slicer.org/slicerWiki/images/d/db/SlicerExtensions-SlicerDeveloperToolsForExtensions-Screenshot-panels.png
+
+# 0 or 1: Define if the extension should be enabled after its installation.
+enabled 1


### PR DESCRIPTION
This extension exposes some functions that are useful for developers. So far, it allows to install an extension directly from its archive (*.tar.gz or *.zip). This is useful to verify that an extension packages correctly. It could also be used to disseminate extensions directly from a laboratory's website or a personal webpage. It also allows a user to load a module into Slicer while Slicer is already running.