### PR TITLE
Updated SlicerIGT extension version

### DIFF
--- a/SlicerIGT.s4ext
+++ b/SlicerIGT.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl https://github.com/SlicerIGT/SlicerIGT.git
-scmrevision 85a5376
+scmrevision master
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files
@@ -15,14 +15,14 @@ scmrevision 85a5376
 depends     NA
 
 # Inner build directory (default is ".")
-build_subdirectory inner-build
+build_subdirectory .
 
 # homepage
 homepage    http://www.slicerigt.org
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
 # For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)
-contributors Tamas Ungi (Queen's University), Junichi Tokuda (Brigham and Women's Hospital)
+contributors Tamas Ungi (Queen's University), Junichi Tokuda (Brigham and Women's Hospital), Andras Lasso (Queen's University),  Isaiah Norton (Brigham and Women's Hospital), Matthew Holden (Queen's University), Laurent Chauvin (SNR), Atsushi Yamada (SNR), Franklin King (Queen's University), Jaime Garcia-Guevara (Queen's University), Amelie Meyer (Queen's University)
 
 # Match category in the xml description of the module (where it shows up in Modules menu)
 category    IGT


### PR DESCRIPTION
Through superbuild mechanism we've been automatically pulling the latest versions from the repository and it worked great for years. Now we don't use superbuild anymore but we would like to keep pulling the latest version from SlicerIGT master automatically, so changed revision identifier from a specific git hash to master.