### PR TITLE
add PETTumorSegmentation to stable Slicer 4.4

### DIFF
--- a/PETTumorSegmentation.s4ext
+++ b/PETTumorSegmentation.s4ext
@@ -1,0 +1,44 @@
+#
+# First token of each non-comment line is the keyword and the rest of the line
+# (including spaces) is the value.
+# - the value can be blank
+#
+
+# This is source code manager (i.e. svn)
+scm git
+scmurl https://github.com/QIICR/PETTumorSegmentation.git
+scmrevision e4100d649937e0ea4294acdcc208212be7102c0b
+
+# list dependencies
+# - These should be names of other modules that have .s4ext files
+# - The dependencies will be built first
+depends     NA
+
+# Inner build directory (default is ".")
+build_subdirectory .
+
+# homepage
+homepage    http://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/PETTumorSegmentation
+
+# Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
+# For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)
+contributors Christian Bauer (University of Iowa), Markus van Tol (University of Iowa), Andrey Fedorov (SPL), Ethan Ulrich (University of Iowa), Reinhard Beichel (University of Iowa), John Buatti (University of Iowa)
+
+# Match category in the xml description of the module (where it shows up in Modules menu)
+category    Segmentation
+
+# url to icon (png, size 128x128 pixels)
+iconurl     https://raw.githubusercontent.com/QIICR/PETTumorSegmentation/master/PETTumorSegmentation.png
+
+# Give people an idea what to expect from this code
+#  - Is it just a test or something you stand behind?
+status      
+
+# One line stating what the module does
+description Tumor and lymph node segmentation in PET scans
+
+# Space separated list of urls
+screenshoturls http://www.slicer.org/slicerWiki/images/0/04/PETTumorSegmentation_Effect_with_models.png
+
+# 0 or 1: Define if the extension should be enabled after its installation.
+enabled 1


### PR DESCRIPTION
I tested our PETTumorSegmentation tool building it against nightly Slicer releases. It works on all platforms and is available through the Extension Manager. I also compiled the extension's source code against the Slicer 4.4. source code, which also works without issues. The tool has reached a stable status and I'd like to add the extension to the stable Slicer v.4.4