### PR TITLE
add PET-IndiC Extension

### DIFF
--- a/PET-IndiC.s4ext
+++ b/PET-IndiC.s4ext
@@ -1,0 +1,44 @@
+#
+# First token of each non-comment line is the keyword and the rest of the line
+# (including spaces) is the value.
+# - the value can be blank
+#
+
+# This is source code manager (i.e. svn)
+scm git
+scmurl https://github.com/ejulrich/PET-IndiC.git
+scmrevision e35c8a3
+
+# list dependencies
+# - These should be names of other modules that have .s4ext files
+# - The dependencies will be built first
+depends     NA
+
+# Inner build directory (default is ".")
+build_subdirectory .
+
+# homepage
+homepage    http://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/PET-IndiC
+
+# Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
+# For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)
+contributors Ethan Ulrich (University of Iowa), Christian Bauer (University of Iowa), Markus van Tol (University of Iowa), Andrey Fedorov (SPL), Reinhard R. Beichel (University of Iowa), John Buatti (University of Iowa)
+
+# Match category in the xml description of the module (where it shows up in Modules menu)
+category    Quantification
+
+# url to icon (png, size 128x128 pixels)
+iconurl     https://raw.githubusercontent.com/ejulrich/PET-IndiC/master/PET-IndiC.png
+
+# Give people an idea what to expect from this code
+#  - Is it just a test or something you stand behind?
+status      
+
+# One line stating what the module does
+description The PET-IndiC allows for fast segmentation of regions of interest and calculation of quantitative indices.
+
+# Space separated list of urls
+screenshoturls http://www.slicer.org/slicerWiki/images/3/32/PET-IndiC_Screenshot1.png http://www.slicer.org/slicerWiki/images/8/8b/PET-IndiC_Screenshot3.png http://www.slicer.org/slicerWiki/images/8/8e/PET-IndiC_Screenshot5.png
+
+# 0 or 1: Define if the extension should be enabled after its installation.
+enabled 1


### PR DESCRIPTION
PET-IndiC extends the Editor module to allow simple calculation of quantitative indices. This extension is meant to be coupled with the PET Tumor Segmentation and PET DICOM extensions, but it also works as a stand-alone extension.