### PR TITLE
BUG: Update Reporting to deal with geometric inconsistencies

### DIFF
--- a/Reporting.s4ext
+++ b/Reporting.s4ext
@@ -6,15 +6,15 @@
 
 # This is source code manager (i.e. svn)
 scm git
-scmurl https://github.com/fedorov/Reporting.git
-scmrevision 7b99e96f
+scmurl git://github.com/fedorov/Reporting.git
+scmrevision 5fc8b8c
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files
 # - The dependencies will be built first
 depends     NA
 
-# Inner build directory (default is .)
+# Inner build directory (default is ".")
 build_subdirectory .
 
 # homepage
@@ -31,7 +31,7 @@ category    Informatics
 iconurl     http://wiki.slicer.org/slicerWiki/images/3/31/ReportingLogo.png
 
 # Give people an idea what to expect from this code
-#  - Is it just a test or something you stand beind?
+#  - Is it just a test or something you stand behind?
 status      Work in progress
 
 # One line stating what the module does


### PR DESCRIPTION
Use the volumes logic CheckForLabelVolumeValidity to get a verbose
report, and ResampleVolumeToReferenceVolume to resample.
Updated the Segmentation object script to do the same, and ensure
proper output scalar type.
Use argparse for more robust script arguments.

Reporting Issue #42