### PR TITLE
BUG: fix segmentation plugin references to DICOMLoadable

### DIFF
--- a/Reporting.s4ext
+++ b/Reporting.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl git://github.com/fedorov/Reporting.git
-scmrevision e787f9b
+scmrevision d936e07
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files


### PR DESCRIPTION
Update the DICOM Segementation plugin to work after a python
namespace change in the way it needs to access DICOMLoadable.
One commit is new:
https://github.com/fedorov/Reporting/commit/d936e0768ee187c36410155fa771aaf2e90c0063

Reporting issue #48