### PR TITLE
update T1_Mapping.s4ext

### DIFF
--- a/T1_Mapping.s4ext
+++ b/T1_Mapping.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl https://github.com/stevedaxiao/T1_Mapping.git
-scmrevision 2c32261
+scmrevision 7c96d50
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files


### PR DESCRIPTION
Dear Slicer Developer,
Not similar to the previous version, the latest nightly version of Slicer doesn't do "import string" by default, I have to add this line and update my python module to let the module work. 
Also the batch mode should be added as well.

Thanks and best regards,

Xiao