### PR TITLE
ENH: Add SlicerCIP extension

### DIFF
--- a/SlicerCIP.s4ext
+++ b/SlicerCIP.s4ext
@@ -1,0 +1,13 @@
+build_subdirectory inner-build
+category Chest Imaging Platform
+contributors Applied Chest Imaging Laboratory, Brigham and Women's Hospital
+depends NA
+description Chest Imaging Platform is an extension for quantitative CT imaging biomarkers for lung diseases. This work is funded by the National Heart, Lung, And Blood Institute of the National  Institutes of Health under Award Number R01HL116931. The content is solely the responsibility of the authors and does not necessarily represent the official views of the National Institutes of Health.
+enabled 1
+homepage http://www.chestimagingplatform.org
+iconurl https://raw.githubusercontent.com/acil-bwh/SlicerCIP/master/Resources/SlicerCIPLogo.png
+scm git
+scmrevision 5fa5c16adc6d7223c1c24b307c1cade0c36fef82
+scmurl https://github.com/acil-bwh/SlicerCIP.git
+screenshoturls https://raw.githubusercontent.com/acil-bwh/SlicerCIP/master/Resources/Screenshot1.png https://raw.githubusercontent.com/acil-bwh/SlicerCIP/master/Resources/Screenshot2.png
+status Alpha


### PR DESCRIPTION
Description:
Chest Imaging Platform is an extension for quantitative CT imaging
biomarkers for lung diseases. This work is funded by the National Heart,
Lung, And Blood Institute of the National  Institutes of Health under
Award Number R01HL116931. The content is solely the responsibility of
the authors and does not necessarily represent the official views of the
National Institutes of Health.

Contributors:
Applied Chest Imaging Laboratory, Brigham and Women's Hospital
