### PR TITLE
update SlicerProstate hash to use master

### DIFF
--- a/SlicerProstate.s4ext
+++ b/SlicerProstate.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl git://github.com/SlicerProstate/SlicerProstate.git
-scmrevision 0722f28a78a25d9139eb558e01f456520b0ea65b
+scmrevision master
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files


### PR DESCRIPTION
This follows the approach earleir adopted by SlicerIGT to simplify the extension
update process, see this commit: https://github.com/Slicer/ExtensionsIndex/commit/23f33c907839259d2040023c1117d27ba46a2f7f