### PR TITLE
ENH: Add Q3DC extension

### DIFF
--- a/Q3DC.s4ext
+++ b/Q3DC.s4ext
@@ -1,0 +1,14 @@
+build_subdirectory .
+category Shape Analysis
+contributors Lucie Macron (University of Michigan)
+depends NA
+description This extension contains one module of the same name. Using placed fiducials, it allows users to compute 2D angles: Yaw, Pitch and Roll; and decompose the 3D distance into the three different components: R-L , A-P and S-I. It is possible to compute the middle point between two fiducials and export the values.
+enabled 1
+homepage http://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/Q3DC
+iconurl https://raw.githubusercontent.com/DCBIA-OrthoLab/Q3DCExtension/master/Q3DC.png
+scm git
+scmrevision 9f19cf4b1e7b261588d0ca2d4a8c5dc2283a3d2a 
+scmurl git://github.com/DCBIA-OrthoLab/Q3DCExtension.git
+screenshoturls http://www.slicer.org/slicerWiki/index.php/File:Q3DC_Interface.png
+status
+


### PR DESCRIPTION
Description:
This extension contains one module of the same name. Using placed
fiducials, it allows users to compute 2D angles: Yaw, Pitch and Roll;
and decompose the 3D distance into the three different components: R-L ,
A-P and S-I. It is possible to compute the middle point between two
fiducials and export the values.

Contributors:
Lucie Macron (University of Michigan)