### PR TITLE
ENH: Change repository location for MeshStatisticsExtension

### DIFF
--- a/MeshStatisticsExtension.s4ext
+++ b/MeshStatisticsExtension.s4ext
@@ -1,13 +1,44 @@
-build_subdirectory .
-category Shape Analysis
-contributors Lucie Macron (University of Michigan)
-depends ModelToModelDistance
-description Mesh Statistics allows users to compute descriptive statistics over specific and predefined regions
-enabled 1
-homepage http://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/MeshStatistics
-iconurl https://raw.githubusercontent.com/DCBIA-OrthoLab/MeshStatisticsExtension/master/MeshStatistics/Resources/Icons/MeshStatistics.png
+#
+# First token of each non-comment line is the keyword and the rest of the line
+# (including spaces) is the value.
+# - the value can be blank
+#
+
+# This is source code manager (i.e. svn)
 scm git
-scmrevision 06222bdcf54fd6263abcba8e52f81a2ce0b95462
-scmurl git://github.com/luciemac/MeshStatisticsExtension.git
+scmurl git://github.com/DCBIA-OrthoLab/MeshStatisticsExtension.git
+scmrevision 06222bd
+
+# list dependencies
+# - These should be names of other modules that have .s4ext files
+# - The dependencies will be built first
+depends     ModelToModelDistance
+
+# Inner build directory (default is ".")
+build_subdirectory .
+
+# homepage
+homepage    http://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/MeshStatistics
+
+# Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
+# For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)
+contributors Lucie Macron (University of Michigan)
+
+# Match category in the xml description of the module (where it shows up in Modules menu)
+category    Shape Analysis
+
+# url to icon (png, size 128x128 pixels)
+iconurl     https://raw.githubusercontent.com/DCBIA-OrthoLab/MeshStatisticsExtension/master/MeshStatistics/Resources/Icons/MeshStatistics.png
+
+# Give people an idea what to expect from this code
+#  - Is it just a test or something you stand behind?
+status      
+
+# One line stating what the module does
+description Mesh Statistics allows users to compute descriptive statistics over specific and predefined regions
+
+# Space separated list of urls
 screenshoturls http://www.slicer.org/slicerWiki/index.php/File:MeshStatistics_Interface.png
-status
+
+# 0 or 1: Define if the extension should be enabled after its installation.
+enabled 1


### PR DESCRIPTION
MeshStatisticsExtension repository was on a personal github repository. For maintenance purposes, it was forked to the DCBIA-OrthoLab github repository and the up-to-date repository will from now on be the DCBIA-OrthoLab github project repository.