### PR TITLE
ENH: SlicerRT nightly now builds the current master of its repository…

### DIFF
--- a/SlicerRT.s4ext
+++ b/SlicerRT.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm svn
 scmurl https://subversion.assembla.com/svn/slicerrt/trunk/SlicerRt/src
-scmrevision 2320
+scmrevision master
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files


### PR DESCRIPTION
…, similarly to other extensions. This is to make releases less error-prone, and to make use of the automatic testing so that the developers are warned about regressions overnight, without manual interaction.