### PR TITLE
BUG: SPHARM-PDM, when built as an extension, is not technically a sup…

### DIFF
--- a/SPHARM-PDM.s4ext
+++ b/SPHARM-PDM.s4ext
@@ -15,7 +15,7 @@ scmrevision 1e847bb4b704239ce424851f92e25c2561ef5cff
 depends     NA
 
 # Inner build directory (default is .)
-build_subdirectory SPHARM-PDM-build
+build_subdirectory .
 
 # homepage
 homepage    http://www.nitrc.org/projects/spharm-pdm


### PR DESCRIPTION
…erbuild

 project anymore.

All the tools are installed in the outer-build to avoid reset problems with
CMake when packaging the extension. The build_subdirectory has to be set to '.'