### PR TITLE
Update GraphCutSegment extension

### DIFF
--- a/GraphCutSegment.s4ext
+++ b/GraphCutSegment.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl https://github.com/DaphneCD/GraphCutSegmentExtension.git
-scmrevision b7fc216
+scmrevision 96b497b
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files
@@ -35,7 +35,7 @@ iconurl     https://raw.githubusercontent.com/DaphneCD/GraphCutSegmentExtension/
 status      
 
 # One line stating what the module does
-description This is a segment extension using graph cut and star shape algorithm. This extension can be used for research purposes ONLY. It can NOT be used for commercial purposes.
+description This is a segment extension using graph cut algorithm.
 
 # Space separated list of urls
 screenshoturls https://raw.githubusercontent.com/DaphneCD/GraphCutSegmentExtension/master/screenshot.png


### PR DESCRIPTION
This is an update of GraphCutSegment extension.
This version fix the crush when closing the scene.
The code comparison is shown in the link below.
https://github.com/DaphneCD/GraphCutSegmentExtension/compare/b7fc216...96b497b