### PR TITLE
BUG: This project used to be built as a superbuild project and theref…

### DIFF
--- a/DTIProcess.s4ext
+++ b/DTIProcess.s4ext
@@ -15,7 +15,7 @@ scmrevision 8cd9ff04131fd2c7c7baaa64de6eee57b19d4e36
 depends     NA
 
 # Inner build directory (default is .)
-build_subdirectory DTIProcess-build
+build_subdirectory .
 
 # homepage
 homepage    http://www.nitrc.org/projects/dtiprocess


### PR DESCRIPTION
…ore the build_subdirectory was set to the inner-build directory of the project. Because of problems using superbuild (reconfiguration, erasing CMake variables in the inner-build directory), this project does not explicitly use the superbuild system when compiling as a Slicer extension. the variable "build_directory" had not been updated in the description file.