### PR TITLE
BUG: Remove new line characters in CMake variables

### DIFF
--- a/MeshToLabelMap.s4ext
+++ b/MeshToLabelMap.s4ext
@@ -6,36 +6,36 @@
 
 # This is source code manager (i.e. svn)
 scm git
-scmurl https://github.com/NIRALUser/MeshToLabelMap.git
-scmrevision 101bbadb07d57d57cb36ceea5e4f2e20bebdca37
+scmurl git://github.com/NIRALUser/MeshToLabelMap.git
+scmrevision b0be1f0
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files
 # - The dependencies will be built first
 depends     NA
 
-# Inner build directory (default is .)
+# Inner build directory (default is ".")
 build_subdirectory .
 
 # homepage
-homepage   http://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/MeshToLabelMap
+homepage    http://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/MeshToLabelMap
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
 # For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)
-contributors Francois Budin (UNC)
+contributors Francois Budin (UNC), Ipek Oguz (University of Iowa)
 
 # Match category in the xml description of the module (where it shows up in Modules menu)
 category    Shape Analysis
 
 # url to icon (png, size 128x128 pixels)
-iconurl    https://raw.githubusercontent.com/NIRALUser/MeshToLabelMap/master/icons/MeshToLabelMapIcon128x128.png
+iconurl     https://raw.githubusercontent.com/NIRALUser/MeshToLabelMap/master/icons/MeshToLabelMapIcon128x128.png
 
 # Give people an idea what to expect from this code
-#  - Is it just a test or something you stand beind?
-status   Release
+#  - Is it just a test or something you stand behind?
+status      Release
 
 # One line stating what the module does
-description This extension computes a label map from a 3D model
+description This extension computes a label map from a 3D model.
 
 # Space separated list of urls
 screenshoturls http://slicer.org/slicerWiki/images/thumb/5/54/MeshToLabelMapScreenshot.png/800px-MeshToLabelMapScreenshot.png


### PR DESCRIPTION
New line characters in CMake variables are creating problems. It was not possible to upload the package of the 3D Slicer extension on the Midas serv
er.

https://github.com/fbudin69500/MeshToLabelMap/compare/101bbadb07d57d57cb36ceea5e4f2e20bebdca37%E2%80%A6b0be1f0ded2d64535440755e1c4d0f7098e2cd81