### PR TITLE
BUG: Remove new line characters in CMake variables

### DIFF
--- a/Q3DC.s4ext
+++ b/Q3DC.s4ext
@@ -1,14 +1,44 @@
-build_subdirectory .
-category Shape Analysis
-contributors Lucie Macron (University of Michigan)
-depends NA
-description This extension contains one module of the same name. Using placed fiducials, it allows users to compute 2D angles: Yaw, Pitch and Roll; and decompose the 3D distance into the three different components: R-L , A-P and S-I. It is possible to compute the middle point between two fiducials and export the values.
-enabled 1
-homepage http://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/Q3DC
-iconurl https://raw.githubusercontent.com/DCBIA-OrthoLab/Q3DCExtension/master/Q3DC.png
-scm git
-scmrevision f4984c8cd724d70dc404e0d88fd5a10b19068eec 
-scmurl git://github.com/DCBIA-OrthoLab/Q3DCExtension.git
-screenshoturls http://www.slicer.org/slicerWiki/index.php/File:Q3DC_Interface.png
-status
+#
+# First token of each non-comment line is the keyword and the rest of the line
+# (including spaces) is the value.
+# - the value can be blank
+#
 
+# This is source code manager (i.e. svn)
+scm git
+scmurl git://github.com/DCBIA-OrthoLab/Q3DCExtension.git
+scmrevision 18e3f14
+
+# list dependencies
+# - These should be names of other modules that have .s4ext files
+# - The dependencies will be built first
+depends     NA
+
+# Inner build directory (default is ".")
+build_subdirectory .
+
+# homepage
+homepage    http://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/Q3DC
+
+# Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
+# For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)
+contributors Lucie Macron (University of Michigan)
+
+# Match category in the xml description of the module (where it shows up in Modules menu)
+category    Shape Analysis
+
+# url to icon (png, size 128x128 pixels)
+iconurl     https://raw.githubusercontent.com/DCBIA-OrthoLab/Q3DCExtension/master/Q3DC.png
+
+# Give people an idea what to expect from this code
+#  - Is it just a test or something you stand behind?
+status      
+
+# One line stating what the module does
+description This extension contains one module of the same name. Using placed fiducials, it allows users to compute 2D angles: Yaw, Pitch and Roll
+
+# Space separated list of urls
+screenshoturls http://www.slicer.org/slicerWiki/index.php/File:Q3DC_Interface.png
+
+# 0 or 1: Define if the extension should be enabled after its installation.
+enabled 1


### PR DESCRIPTION
New line characters in CMake variables are creating problems. It was not possible to upload the package of the 3D Slicer extension on the Midas server.

https://github.com/DCBIA-OrthoLab/Q3DCExtension/compare/f4984c8cd724d70dc404e0d88fd5a10b19068eec%E2%80%A618e3f14751ab4a5eb08bc5254c0b00eb39279ebb