### PR TITLE
BUG: Remove new line characters in CMake variables

### DIFF
--- a/Q3DC.s4ext
+++ b/Q3DC.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl git://github.com/DCBIA-OrthoLab/Q3DCExtension.git
-scmrevision f4984c8cd724d70dc404e0d88fd5a10b19068eec
+scmrevision 18e3f14
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files


### PR DESCRIPTION
New line characters in CMake variables are creating problems. It was not possible to upload the package of the 3D Slicer extension on the Midas server.

https://github.com/DCBIA-OrthoLab/Q3DCExtension/compare/f4984c8cd724d70dc404e0d88fd5a10b19068eec%E2%80%A618e3f14751ab4a5eb08bc5254c0b00eb39279ebb