### PR TITLE
Update GraphCutSegment extension 

### DIFF
--- a/GraphCutSegment.s4ext
+++ b/GraphCutSegment.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl https://github.com/DaphneCD/GraphCutSegmentExtension.git
-scmrevision 96b497b
+scmrevision 5c9dcd9
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files
@@ -35,10 +35,9 @@ iconurl     https://raw.githubusercontent.com/DaphneCD/GraphCutSegmentExtension/
 status      
 
 # One line stating what the module does
-description This is a segment extension using graph cut algorithm.
+description This is a segment extension using graph cut and star shape algorithm. This extension can be used for research purposes ONLY. It can NOT be used for commercial purposes.
 
 # Space separated list of urls
 screenshoturls https://raw.githubusercontent.com/DaphneCD/GraphCutSegmentExtension/master/screenshot.png
-
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 1


### PR DESCRIPTION
Replace itoa with sprintf to avoid the build error on Mac.
Fix the vtkCollection leak by deleting unecessary GetNodesByName calling.

The code comparison is shown in the link below.
https://github.com/DaphneCD/GraphCutSegmentExtension/compare/96b497b...5c9dcd9