### PR TITLE
BUG: dependencies and build_subdirectory of DTIAtlasFiberAnalyzer had…

### DIFF
--- a/DTIAtlasFiberAnalyzer.s4ext
+++ b/DTIAtlasFiberAnalyzer.s4ext
@@ -12,10 +12,10 @@ scmrevision cbf6450c31f8d1e608772d01419d2d08fc70ebba
 #list dependencies
 # - These should be names of other modules that have .s4ext files
 # - The dependencies will be built first
-depends  NA
+depends  DTIProcess
 
 # Inner build directory (default is .)
-build_subdirectory dti_tract_stat-build
+build_subdirectory .
 
 #homepage
 homepage http://www.nitrc.org/projects/dti_tract_stat
@@ -29,7 +29,7 @@ category Diffusion
 iconurl http://www.nitrc.org/project/screenshot.php?group_id=403&screenshot_id=606
 
 # Extension development status
-status Beta
+status 
 
 # One line stating what the module does
 description DTIAtlasFiberAnalyzer allows the user to study the behavior of water diffusion (using DTI data) along the length of the white matter fiber-tracts.


### PR DESCRIPTION
… not been updated.

In the previous commit concerning DTIAtlasFiberAnalyzer, it's dependencies and build_subdirectory have been changed but have not been updated in its extension description file.