### PR TITLE
ENH: Add LabelAtlasEditor extension

### DIFF
--- a/LabelAtlasEditor.s4ext
+++ b/LabelAtlasEditor.s4ext
@@ -1,0 +1,13 @@
+build_subdirectory .
+category Segmentation
+contributors Jessica Forbes (University of Iowa), Hans Johnson (University of Iowa)
+depends NA
+description This module is for editing label atlases and automatically cleaning small islands of disconnected voxels.
+enabled 1
+homepage http://brainsia.github.io/LabelAtlasEditor
+iconurl https://github.com/BRAINSia/LabelAtlasEditor/blob/master/LabelAtlasEditor/Resources/Icons/LabelAtlasEditor.png
+scm git
+scmrevision 1c6e4be53967fbb0c7fcb856d56dd82453c49b70
+scmurl git://github.com/BRAINSia/LabelAtlasEditor.git
+screenshoturls https://github.com/BRAINSia/LabelAtlasEditor/blob/master/automaticDustCleaningWidget.png https://github.com/BRAINSia/LabelAtlasEditor/blob/master/labelSuggestionWidget.png https://github.com/BRAINSia/LabelAtlasEditor/blob/master/mergeWidget.png https://github.com/BRAINSia/LabelAtlasEditor/blob/master/LabelAtlasEditor.png
+status


### PR DESCRIPTION
Description:
This module is for editing label atlases and automatically cleaning
small islands of disconnected voxels.

Contributors:
Jessica Forbes (University of Iowa), Hans Johnson (University of Iowa)
