### PR TITLE
BUG: Update Reporting to fix CLI discovery

### DIFF
--- a/Reporting.s4ext
+++ b/Reporting.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl https://github.com/QIICR/Reporting.git
-scmrevision 33c8ce419f63b1880b351b19fa8ede4265f2c235
+scmrevision 8d2577ddf8283daecc02e9345dad149cac617b49
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files


### PR DESCRIPTION
Update the Reporting extension to include the fix for
more robust discovery of the seg2nrrd CLI module. Without
this the loading of DICOM Segmentation objects will hang
if the CLI wasn't properly installed.