### PR TITLE
add Self Test for GraphCutSegmentExtension

### DIFF
--- a/GraphCutSegment.s4ext
+++ b/GraphCutSegment.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl https://github.com/DaphneCD/GraphCutSegmentExtension.git
-scmrevision 479188c
+scmrevision 2c4e572
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files


### PR DESCRIPTION
Self Test is added into GraphCutSegmentExtension. The comparison of new commit and previous commit can be found here https://github.com/DaphneCD/GraphCutSegmentExtension/compare/479188c...2c4e572 .

I followed the instruction for Self Test Module to create the Self Test as a module. On my local build Slicer, I tried the Self Test module and it passed testing. But I'm not sure how to add the test into the extension. So I simply add the Python test file under Testing folder. The complete Self Test Module code can be found here https://github.com/DaphneCD/GraphCutSegmentSelfTest . Plase let me know if there is any problem.

Another thing is that there is an odd situation for my extension. It works totally fine on Mac. But on Windows it will have Slicer stop working problem with proper operation. The proper process is the work flow in Self Test. Hope it can help with finding the reason for Windows version crash problem.

Thanks!
Daphne