### PR TITLE
ENH: Update CMFreg extension

### DIFF
--- a/CMFreg.s4ext
+++ b/CMFreg.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl https://github.com/DCBIA-OrthoLab/CMFreg.git
-scmrevision abd56155baa6df041238b9a3bd0738c62d99489e
+scmrevision 8602af01ca762a93e9a582eaa9e1a6445c3b4b3e
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files


### PR DESCRIPTION
This updates the CMFreg extension to 8602af01ca762a93e9a582eaa9e1a6445c3b4b3e.


See https://github.com/DCBIA-OrthoLab/CMFreg/compare/abd56155baa6df041238b9a3bd0738c62d99489e...8602af01ca762a93e9a582eaa9e1a6445c3b4b3e to view changes to the extension.