### PR TITLE
ENH: Update PickAndPaintExtension extension

### DIFF
--- a/PickAndPaintExtension.s4ext
+++ b/PickAndPaintExtension.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl https://github.com/DCBIA-OrthoLab/PickAndPaintExtension.git
-scmrevision b3a677cd48fd4583f3fb3a05f37800afa5c37ee5
+scmrevision 8100cc4ca202eace942eaab29243f91f1e519bf7
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files


### PR DESCRIPTION
This updates the PickAndPaintExtension extension to 8100cc4ca202eace942eaab29243f91f1e519bf7.


See https://github.com/DCBIA-OrthoLab/PickAndPaintExtension/compare/b3a677cd48fd4583f3fb3a05f37800afa5c37ee5...8100cc4ca202eace942eaab29243f91f1e519bf7 to view changes to the extension.