### PR TITLE
Update GraphCutSegment extension

### DIFF
--- a/GraphCutSegment.s4ext
+++ b/GraphCutSegment.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl https://github.com/DaphneCD/GraphCutSegmentExtension.git
-scmrevision df80314
+scmrevision 2d0a0f8
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files


### PR DESCRIPTION
The comparison of code can be found below.
https://github.com/DaphneCD/GraphCutSegmentExtension/compare/df80314...2d0a0f8

Removed unnecessary debug code which causing crash. 
The "save" function which calls the fopen will cause crash because without a proper directory. Since "save" is only for debug use when testing the code, I just simply removed it. 