### PR TITLE
ENH: Update Q3DC extension

### DIFF
--- a/Q3DC.s4ext
+++ b/Q3DC.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl https://github.com/DCBIA-OrthoLab/Q3DCExtension.git
-scmrevision 7cf4706854991efc8547dcfd8a3c919e6d147aee
+scmrevision d0d5bd1015d4f15a834112b2dde93c8bc582b80b
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files


### PR DESCRIPTION
This updates the Q3DC extension to d0d5bd1015d4f15a834112b2dde93c8bc582b80b.


See https://github.com/DCBIA-OrthoLab/Q3DCExtension/compare/7cf4706854991efc8547dcfd8a3c919e6d147aee...d0d5bd1015d4f15a834112b2dde93c8bc582b80b to view changes to the extension.