### PR TITLE
ENH: Update PickAndPaintExtension extension

### DIFF
--- a/PickAndPaintExtension.s4ext
+++ b/PickAndPaintExtension.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl https://github.com/DCBIA-OrthoLab/PickAndPaintExtension.git
-scmrevision 3189c17e92f1d2e2fa6115f91d7f9da86188002c
+scmrevision 070ed9caaf79b0776515261a455dfb308451bc8a
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files


### PR DESCRIPTION
This updates the PickAndPaintExtension extension to 070ed9caaf79b0776515261a455dfb308451bc8a.


See https://github.com/DCBIA-OrthoLab/PickAndPaintExtension/compare/3189c17e92f1d2e2fa6115f91d7f9da86188002c...070ed9caaf79b0776515261a455dfb308451bc8a to view changes to the extension.