### PR TITLE
ENH: Update Q3DC extension

### DIFF
--- a/Q3DC.s4ext
+++ b/Q3DC.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl https://github.com/DCBIA-OrthoLab/Q3DCExtension.git
-scmrevision d0d5bd1015d4f15a834112b2dde93c8bc582b80b
+scmrevision 8b5d45a6af1ab67f124e9601a6c0d4ed05f37f0e
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files


### PR DESCRIPTION
This updates the Q3DC extension to 8b5d45a6af1ab67f124e9601a6c0d4ed05f37f0e.


See https://github.com/DCBIA-OrthoLab/Q3DCExtension/compare/d0d5bd1015d4f15a834112b2dde93c8bc582b80b...8b5d45a6af1ab67f124e9601a6c0d4ed05f37f0e to view changes to the extension.