### PR TITLE
ENH: Update Q3DC extension

### DIFF
--- a/Q3DC.s4ext
+++ b/Q3DC.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl https://github.com/DCBIA-OrthoLab/Q3DCExtension.git
-scmrevision master
+scmrevision 4.5-stable-release
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files

--- a/Q3DC.s4ext
+++ b/Q3DC.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl https://github.com/DCBIA-OrthoLab/Q3DCExtension.git
-scmrevision 4f67a3440d024ef6ee58b7e74978196e128afd22
+scmrevision master
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files

--- a/Q3DC.s4ext
+++ b/Q3DC.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl https://github.com/DCBIA-OrthoLab/Q3DCExtension.git
-scmrevision 8b5d45a6af1ab67f124e9601a6c0d4ed05f37f0e
+scmrevision 4f67a3440d024ef6ee58b7e74978196e128afd22
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files


### PR DESCRIPTION
This updates the Q3DC extension to 4f67a3440d024ef6ee58b7e74978196e128afd22.


See https://github.com/DCBIA-OrthoLab/Q3DCExtension/compare/8b5d45a6af1ab67f124e9601a6c0d4ed05f37f0e...4f67a3440d024ef6ee58b7e74978196e128afd22 to view changes to the extension.