### PR TITLE
ENH: Add OpenCVExample extension

### DIFF
--- a/OpenCVExample.s4ext
+++ b/OpenCVExample.s4ext
@@ -1,0 +1,44 @@
+#
+# First token of each non-comment line is the keyword and the rest of the line
+# (including spaces) is the value.
+# - the value can be blank
+#
+
+# This is source code manager (i.e. svn)
+scm git
+scmurl git://github.com/naucoin/OpenCVExample.git
+scmrevision 814015e
+
+# list dependencies
+# - These should be names of other modules that have .s4ext files
+# - The dependencies will be built first
+depends     SlicerOpenCV
+
+# Inner build directory (default is ".")
+build_subdirectory .
+
+# homepage
+homepage    http://slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/OpenCVExample
+
+# Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
+# For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)
+contributors Nicole Aucoin (BWH)
+
+# Match category in the xml description of the module (where it shows up in Modules menu)
+category    Examples
+
+# url to icon (png, size 128x128 pixels)
+iconurl     https://raw.githubusercontent.com/nicole/OpenCVExample/master/OpenCVExample.png
+
+# Give people an idea what to expect from this code
+#  - Is it just a test or something you stand behind?
+status      
+
+# One line stating what the module does
+description This is an example of an extension that depends on the SlicerOpenCV extension
+
+# Space separated list of urls
+screenshoturls 
+
+# 0 or 1: Define if the extension should be enabled after its installation.
+enabled 1


### PR DESCRIPTION
The OpenCVExample extension provide a template for other extensions
to follow when building and running against the SlicerOpenCV extension.
It provides the BlendVectorVolumes CLI that uses the cv::addWeighted
method to blend together two vector volumes
The extension and module documentation pages on the wiki provide
details on how to use this extension as a template to use opencv
via the SlicerOpenCV extension.