### PR TITLE
COMP: Update for dashboard linking.

### DIFF
--- a/OpenCVExample.s4ext
+++ b/OpenCVExample.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl git://github.com/naucoin/OpenCVExample.git
-scmrevision 814015e
+scmrevision a41ac09
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files


### PR DESCRIPTION
This update to the OpenCVExample extension provides a FindSlicerOpenCV.cmake
file that will help with building against the SlicerOpenCV extension on the dashboard.

https://github.com/SBU-BMI/SlicerOpenCV/issues/6