### PR TITLE
ENH: Update OpenCVExample

### DIFF
--- a/OpenCVExample.s4ext
+++ b/OpenCVExample.s4ext
@@ -6,33 +6,33 @@
 
 # This is source code manager (i.e. svn)
 scm git
-scmurl git://github.com/naucoin/OpenCVExample.git
-scmrevision 455c29d
+scmurl git://github.com/SBU-BMI/OpenCVExample.git
+scmrevision 3415776
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files
 # - The dependencies will be built first
-depends     SlicerOpenCV
+depends SlicerOpenCV
 
 # Inner build directory (default is ".")
 build_subdirectory .
 
 # homepage
-homepage    http://slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/OpenCVExample
+homepage http://slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/OpenCVExample
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
 # For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)
 contributors Nicole Aucoin (BWH)
 
 # Match category in the xml description of the module (where it shows up in Modules menu)
-category    Examples
+category Examples
 
 # url to icon (png, size 128x128 pixels)
-iconurl     https://raw.githubusercontent.com/naucoin/OpenCVExample/master/OpenCVExample.png
+iconurl https://raw.githubusercontent.com/SBU-BMI/OpenCVExample/master/OpenCVExample.png
 
 # Give people an idea what to expect from this code
 #  - Is it just a test or something you stand behind?
-status      
+status 
 
 # One line stating what the module does
 description This is an example of an extension that depends on the SlicerOpenCV extension


### PR DESCRIPTION
The OpenCVExample extension was transferred to the SBU-BMI organisation.
This commit updates the extension definition file to point to the new
repository location.