### PR TITLE
Change scmrevision to release

### DIFF
--- a/DTI-Reg.s4ext
+++ b/DTI-Reg.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl https://github.com/NIRALUser/DTI-Reg.git
-scmrevision 3161943f6b6f860d946f926330f64de62d9ee07b
+scmrevision release
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files

--- a/DTIAtlasBuilder.s4ext
+++ b/DTIAtlasBuilder.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl git://github.com/NIRALUser/DTIAtlasBuilder.git
-scmrevision a060360850beece3f35fac6ba60d83e70691bd77
+scmrevision release
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files

--- a/DTIPrep.s4ext
+++ b/DTIPrep.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl https://github.com/NIRALUser/DTIPrep.git
-scmrevision 9a0abb0f9f4ec1c82d3faa044a3af41c614bfe64
+scmrevision release
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files

--- a/DTIProcess.s4ext
+++ b/DTIProcess.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl https://github.com/NIRALUser/DTIProcessToolkit.git
-scmrevision 6afd509c8ece539b379d5a61bccdd6e68092109c
+scmrevision release
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files


### PR DESCRIPTION
The scmrevision is changed to release for the following extensions:
1. DTIPrep
2. DTIAtlasBuilder
3. DTI-Reg
4. DTIProcess