### PR TITLE
add SliceTracker

### DIFF
--- a/SliceTracker.s4ext
+++ b/SliceTracker.s4ext
@@ -1,0 +1,44 @@
+#
+# First token of each non-comment line is the keyword and the rest of the line
+# (including spaces) is the value.
+# - the value can be blank
+#
+
+# This is source code manager (i.e. svn)
+scm git
+scmurl https://github.com/SlicerProstate/SliceTracker.git
+scmrevision master
+
+# list dependencies
+# - These should be names of other modules that have .s4ext files
+# - The dependencies will be built first
+depends SlicerProstate mpReview VolumeClip
+
+# Inner build directory (default is ".")
+build_subdirectory .
+
+# homepage
+homepage https://github.com/SlicerProstate/SliceTracker
+
+# Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
+# For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)
+contributors Christian Herz (SPL), Peter Behringer (SPL), Andrey Fedorov (SPL)
+
+# Match category in the xml description of the module (where it shows up in Modules menu)
+category IGT
+
+# url to icon (png, size 128x128 pixels)
+iconurl http://wiki.slicer.org/slicerWiki/images/8/87/SliceTracker_Logo_1.0_128x128.png
+
+# Give people an idea what to expect from this code
+#  - Is it just a test or something you stand behind?
+status beta
+
+# One line stating what the module does
+description This extension provides modules to support in-bore MRI-guided prostate biopsy.
+
+# Space separated list of urls
+screenshoturls http://wiki.slicer.org/slicerWiki/images/7/78/Slicetracker.gif
+
+# 0 or 1: Define if the extension should be enabled after its installation.
+enabled 1


### PR DESCRIPTION
This is a workflow module to support MRI-guided prostate biopsy

https://github.com/SlicerProstate/SliceTracker

http://wiki.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/SliceTracker