### PR TITLE
BUG: Update SlicerPathology with recent fixes.

### DIFF
--- a/SlicerPathology.s4ext
+++ b/SlicerPathology.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl git://github.com/SBU-BMI/SlicerPathology.git
-scmrevision ae5d1c4
+scmrevision 86538d6
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files


### PR DESCRIPTION
Update the git hash to include fixes for icon, python wrapping in VTK7,
algorithm updates, GUI updates. This fixes building the extension from
the ExtensionsIndex on linux and mac.

> git shortlog ae5d1c4..86538d6
Andrey Fedorov (2):
      BUG: fix icon url
      Merge pull request #50 from fedorov/fix-icon-1

Erich Bremer (12):
      ENH: preliminary web work
      ENH: add zip file generation
      ENH: Add binary post for zip file submissions
      ENH: working version of web selection
      ENH: Increased granularity of parameter sliders
      Merge pull request #48 from msmolens/update-wrap-exclude-vtk7
      BUG: Corrupt PNG File
      ENH: Added label outline toggle and changed default to outline mode
      ENH: added some debugging code
      ENH: filter out alpha channel if present to prevent segmenter crashes
      Merge branch 'master' of https://github.com/SBU-BMI/SlicerPathology
      ENH: remove extraneous routine

Max Smolens (1):
      Fix wrapping exclusions for VTK 7

Yi Gao (8):
      PERF: declumping updated
      Merge branch 'master' of github.com:SBU-BMI/SlicerPathology
      BUG: smallest dim
      update
      up
      STYLE: parameter change
      STYLE: parameter value ranges
      Merge branch 'master' of github.com:SBU-BMI/SlicerPathology