### PR TITLE
ENH: Add SlicerAstro extension

### DIFF
--- a/SlicerAstro.s4ext
+++ b/SlicerAstro.s4ext
@@ -1,0 +1,44 @@
+#
+# First token of each non-comment line is the keyword and the rest of the line
+# (including spaces) is the value.
+# - the value can be blank
+#
+
+# This is source code manager (i.e. svn)
+scm git
+scmurl https://github.com/Punzo/SlicerAstro.git
+scmrevision 782b67913d5ce10417d0ba8724ce25c9039bcff1
+
+# list dependencies
+# - These should be names of other modules that have .s4ext files
+# - The dependencies will be built first
+depends NA
+
+# Inner build directory (default is ".")
+build_subdirectory inner-build
+
+# homepage
+homepage https://github.com/Punzo/SlicerAstro/wiki
+
+# Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
+# For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)
+contributors Davide Punzo (Kapteyn Astronomical Institute), Thijs van der Hulst (Kapteyn Astronomical institute), Jos Roerdink (Johann Bernoulli Institute), Jean-Christophe Fillion-Robin (Kitware)
+
+# Match category in the xml description of the module (where it shows up in Modules menu)
+category Astronomy
+
+# url to icon (png, size 128x128 pixels)
+iconurl https://raw.githubusercontent.com/Punzo/SlicerAstro/master/SlicerAstroIcon.png
+
+# Give people an idea what to expect from this code
+#  - Is it just a test or something you stand behind?
+status 
+
+# One line stating what the module does
+description Extension for enabling Astronomical (HI) visualization in Slicer
+
+# Space separated list of urls
+screenshoturls https://raw.githubusercontent.com/Punzo/SlicerAstroWikiImages/master/Screenshoot.png
+
+# 0 or 1: Define if the extension should be enabled after its installation.
+enabled 1


### PR DESCRIPTION
Description:
Extension for enabling Astronomical (HI) visualization in Slicer

Contributors:
Davide Punzo (Kapteyn Astronomical Institute), Thijs van der Hulst
(Kapteyn Astronomical institute), Jos Roerdink (Johann Bernoulli
Institute), Jean-Christophe Fillion-Robin (Kitware)
