### PR TITLE
update PETDICOMExtension

### DIFF
--- a/PETDICOMExtension.s4ext
+++ b/PETDICOMExtension.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl https://github.com/QIICR/Slicer-PETDICOMExtension.git
-scmrevision d138d558f0b9df1e1466b00d341008af19e77562
+scmrevision 47b746c9be40c225b11c194fbacedc4b0ecbfa98
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files


### PR DESCRIPTION
The Extension was broke because of changes that were made to DCMTK. I had to include an additional DCMTK header to fix the issue.