### PR TITLE
update mpReview dependencies

### DIFF
--- a/mpReview.s4ext
+++ b/mpReview.s4ext
@@ -12,7 +12,7 @@ scmrevision master
 # list dependencies
 # - These should be names of other modules that have .s4ext files
 # - The dependencies will be built first
-depends     WindowLevelEffect SlicerProstate
+depends     SlicerProstate
 
 # Inner build directory (default is ".")
 build_subdirectory .


### PR DESCRIPTION
The extension no longer depends on WindowLevelEffect

cc @che85 

see https://github.com/SlicerProstate/mpReview/issues/142