### PR TITLE
ENH: Add DCMQI extension

### DIFF
--- a/DCMQI.s4ext
+++ b/DCMQI.s4ext
@@ -1,0 +1,44 @@
+#
+# First token of each non-comment line is the keyword and the rest of the line
+# (including spaces) is the value.
+# - the value can be blank
+#
+
+# This is source code manager (i.e. svn)
+scm git
+scmurl git://github.com/QIICR/dcmqi.git
+scmrevision b3ea5fa05f204d2575e2c898b614159a9a56bda7
+
+# list dependencies
+# - These should be names of other modules that have .s4ext files
+# - The dependencies will be built first
+depends NA
+
+# Inner build directory (default is ".")
+build_subdirectory dcmqi-build
+
+# homepage
+homepage https://www.slicer.org/wiki/Documentation/Nightly/Extensions/DCMQI
+
+# Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
+# For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)
+contributors Andrey Fedorov (BWH, SPL), Christian Herz (BWH, SPL), Jean-Christophe Fillion-Robin (Kitware)
+
+# Match category in the xml description of the module (where it shows up in Modules menu)
+category DICOM
+
+# url to icon (png, size 128x128 pixels)
+iconurl https://raw.githubusercontent.com/QIICR/dcmqi/master/dcmqi.png
+
+# Give people an idea what to expect from this code
+#  - Is it just a test or something you stand behind?
+status 
+
+# One line stating what the module does
+description dcmqi (DICOM (dcm) for Quantitative Imaging (qi)) is a collection of libraries and command line tools with minimum dependencies to support standardized communication of quantitative image analysis research data using DICOM standard.
+
+# Space separated list of urls
+screenshoturls https://raw.githubusercontent.com/QIICR/dcmqi/master/Design/DataFlow-001.png
+
+# 0 or 1: Define if the extension should be enabled after its installation.
+enabled 1


### PR DESCRIPTION
Description:
dcmqi (DICOM (dcm) for Quantitative Imaging (qi)) is a collection of
libraries and command line tools with minimum dependencies to support
standardized communication of quantitative image analysis research data
using DICOM standard.

Contributors:
Andrey Fedorov (BWH, SPL), Christian Herz (BWH, SPL), Jean-Christophe
Fillion-Robin (Kitware)
