### PR TITLE
ENH: Add AnomalousFiltersExtension extension

### DIFF
--- a/AnomalousFiltersExtension.s4ext
+++ b/AnomalousFiltersExtension.s4ext
@@ -1,0 +1,13 @@
+build_subdirectory .
+category Filtering
+contributors Antonio Carlos Senra Filho (University of Sao Paulo), Luiz Otavio Murta Junior (University of Sao Paulo)
+depends NA
+description This extension aims to provide several approaches in order to apply the anomalous spatial filters on medical images. The methods provided here are numerical solution of the generalized anomalous diffusion proposed by Constantino Tsallis, which, in other words, provide a numerical solution to the porous media equation (Fokker-Planck anomalous heat equation). At the moment, the Modules available are suppose to be used on scalar volumes, mainly MRI strucutral images namely T1 and T2 weighted images. Future developments will add new functionalities in order to attenuate image noise in other imaging modalities, such as diffusion weighted images (DWI and DTI). More details could be found in the wiki page.
+enabled 1
+homepage http://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/AnomalousFilters
+iconurl https://www.slicer.org/slicerWiki/images/8/89/AnomalousDiffusionExtension-logo.png
+scm git
+scmrevision b061f637d2ac115f3d177ec5bc75e82a2bb2f399
+scmurl https://github.com/CSIM-Toolkits/AnomalousFiltersExtension.git
+screenshoturls https://www.slicer.org/slicerWiki/images/6/64/MRI_raw.png https://www.slicer.org/slicerWiki/images/e/e8/MRI_AAD.png https://www.slicer.org/slicerWiki/images/0/0d/MRI_IAD.png https://www.slicer.org/slicerWiki/images/7/7b/Aad_scalar_gui.png https://www.slicer.org/slicerWiki/images/3/39/Iad_scalar_gui.png
+status


### PR DESCRIPTION
Description:
This extension aims to provide several approaches in order to apply the
anomalous spatial filters on medical images. The methods provided here
are numerical solution of the generalized anomalous diffusion proposed
by Constantino Tsallis, which, in other words, provide a numerical
solution to the porous media equation (Fokker-Planck anomalous heat
equation). At the moment, the Modules available are suppose to be used
on scalar volumes, mainly MRI strucutral images namely T1 and T2
weighted images. Future developments will add new functionalities in
order to attenuate image noise in other imaging modalities, such as
diffusion weighted images (DWI and DTI). More details could be found in
the wiki page.

Contributors:
Antonio Carlos Senra Filho (University of Sao Paulo), Luiz Otavio Murta
Junior (University of Sao Paulo)
