### PR TITLE
add Multi-LevelRegistration

### DIFF
--- a/Multi-LevelRegistration.s4ext
+++ b/Multi-LevelRegistration.s4ext
@@ -1,0 +1,44 @@
+#
+# First token of each non-comment line is the keyword and the rest of the line
+# (including spaces) is the value.
+# - the value can be blank
+#
+
+# This is source code manager (i.e. svn)
+scm git
+scmurl https://github.com/emily-hammond/LongitudinalAnalysis
+scmrevision b92e98c
+
+# list dependencies
+# - These should be names of other modules that have .s4ext files
+# - The dependencies will be built first
+depends NA
+
+# Inner build directory (default is ".")
+build_subdirectory .
+
+# homepage
+homepage http://slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/Multi-LevelRegistration
+
+# Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
+# For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)
+contributors Emily Hammond (University of Iowa), Jessica C. Sieren (University of Iowa) 
+
+# Match category in the xml description of the module (where it shows up in Modules menu)
+category Registratoin
+
+# url to icon (png, size 128x128 pixels)
+iconurl http://www.example.com/Slicer/Extensions/Slicer-MyExtension.png
+
+# Give people an idea what to expect from this code
+#  - Is it just a test or something you stand behind?
+status 
+
+# One line stating what the module does
+description Perform rigid registration with increasingly smaller volumes of data defined by regions of interest focusing on a desired anatomy.
+
+# Space separated list of urls
+screenshoturls http://www.example.com/Slicer/Extensions/Slicer-MyExtension/Screenshots/1.png
+
+# 0 or 1: Define if the extension should be enabled after its installation.
+enabled 1

--- a/Multi-LevelRegistration.s4ext
+++ b/Multi-LevelRegistration.s4ext
@@ -5,9 +5,9 @@
 #
 
 # This is source code manager (i.e. svn)
-scm git
-scmurl https://github.com/emily-hammond/LongitudinalAnalysis
-scmrevision 5ff9f33
+scm local
+scmurl C:/Slicer-related/Multi-LevelRegistration
+scmrevision 0
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files
@@ -25,7 +25,7 @@ homepage http://slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions
 contributors Emily Hammond (University of Iowa), Jessica C. Sieren (University of Iowa) 
 
 # Match category in the xml description of the module (where it shows up in Modules menu)
-category Registratoin
+category Registration
 
 # url to icon (png, size 128x128 pixels)
 iconurl https://github.com/emily-hammond/LongitudinalAnalysis/blob/master/MultiLevelRegistrationLogo_275x235.png

--- a/Multi-LevelRegistration.s4ext
+++ b/Multi-LevelRegistration.s4ext
@@ -6,8 +6,8 @@
 
 # This is source code manager (i.e. svn)
 scm local
-scmurl C:/Slicer-related/Multi-LevelRegistration
-scmrevision 0
+scmurl https://github.com/emily-hammond/Multi-LevelRegistration
+scmrevision master
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files

--- a/Multi-LevelRegistration.s4ext
+++ b/Multi-LevelRegistration.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl https://github.com/emily-hammond/LongitudinalAnalysis
-scmrevision b92e98c
+scmrevision 5ff9f33
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files
@@ -28,7 +28,7 @@ contributors Emily Hammond (University of Iowa), Jessica C. Sieren (University o
 category Registratoin
 
 # url to icon (png, size 128x128 pixels)
-iconurl http://www.example.com/Slicer/Extensions/Slicer-MyExtension.png
+iconurl https://github.com/emily-hammond/LongitudinalAnalysis/blob/master/MultiLevelRegistrationLogo_275x235.png
 
 # Give people an idea what to expect from this code
 #  - Is it just a test or something you stand behind?
@@ -38,7 +38,7 @@ status
 description Perform rigid registration with increasingly smaller volumes of data defined by regions of interest focusing on a desired anatomy.
 
 # Space separated list of urls
-screenshoturls http://www.example.com/Slicer/Extensions/Slicer-MyExtension/Screenshots/1.png
+screenshoturls https://www.slicer.org/wiki/File:MultiLevelRegistrationExample.png
 
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 1


### PR DESCRIPTION
New extension that repeatedly performs rigid registration at multiple levels beginning at the global image and focusing in on a specific region of interest. 