### PR TITLE
ENH: Add ROBEXBrainExtraction extension

### DIFF
--- a/ROBEXBrainExtraction.s4ext
+++ b/ROBEXBrainExtraction.s4ext
@@ -1,0 +1,13 @@
+build_subdirectory .
+category Segmentation
+contributors Antonio Carlos da S. Senra Filho (University of Sao Paulo)
+depends NA
+description This extension aims to extract the brain from the skull. This tool was intensively tested with T1 MRI images, but the pipeline could be applied to any other structural MRI images, namely T2 and PD. This module is an adaptation of ROBEX brain extraction tool, given by Iglesias, J. E. et al (2011). Robust Brain Extraction Across Datasets and Comparison With Publicly Available Methods. IEEE Transactions on Medical Imaging, 30(9). DOI:10.1109/TMI.2011.2138152
+enabled 1
+homepage http://slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/ROBEXBrainExtraction
+iconurl https://www.slicer.org/w/images/7/7a/ROBEXBrainExtraction-logo.png
+scm git
+scmrevision 00cfd12f13c0eba2bd381dbe95fbf261673fcf1f
+scmurl https://github.com/CSIM-Toolkits/ROBEXBrainExtraction.git
+screenshoturls https://www.slicer.org/w/images/c/ca/AllHeadMRI.png https://www.slicer.org/w/images/0/06/BrainMRI.png https://www.slicer.org/w/images/7/71/ROBEXBrainExtraction-GUI.png
+status


### PR DESCRIPTION
Description:
This extension aims to extract the brain from the skull. This tool was
intensively tested with T1 MRI images, but the pipeline could be applied
to any other structural MRI images, namely T2 and PD. This module is an
adaptation of ROBEX brain extraction tool, given by Iglesias, J. E. et
al (2011). Robust Brain Extraction Across Datasets and Comparison With
Publicly Available Methods. IEEE Transactions on Medical Imaging, 30(9).
DOI:10.1109/TMI.2011.2138152

Contributors:
Antonio Carlos da S. Senra Filho (University of Sao Paulo)
