### PR TITLE
add Radiomics

### DIFF
--- a/Radiomics.s4ext
+++ b/Radiomics.s4ext
@@ -1,0 +1,44 @@
+#
+# First token of each non-comment line is the keyword and the rest of the line
+# (including spaces) is the value.
+# - the value can be blank
+#
+
+# This is source code manager (i.e. svn)
+scm git
+scmurl https://github.com/Radiomics/SlicerRadiomics.git
+scmrevision master
+
+# list dependencies
+# - These should be names of other modules that have .s4ext files
+# - The dependencies will be built first
+depends NA
+
+# Inner build directory (default is ".")
+build_subdirectory inner-build
+
+# homepage
+homepage https://www.slicer.org/wiki/Documentation/Nightly/Extensions/Radiomics
+
+# Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
+# For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)
+contributors Andrey Fedorov (SPL), Joost van Griethuysen (NKI), Nicole Aucoin (SPL), Jean-Christophe Fillion-Robin (Kitware), Steve Pieper (Isomics), Hugo Aerts (DFCI)
+
+# Match category in the xml description of the module (where it shows up in Modules menu)
+category Informatics
+
+# url to icon (png, size 128x128 pixels)
+iconurl https://www.slicer.org/w/images/6/6b/RadiomicsExtension.png
+
+# Give people an idea what to expect from this code
+#  - Is it just a test or something you stand behind?
+status beta
+
+# One line stating what the module does
+description Radiomics extension provides a 3D Slicer interface to the pyradiomics library. pyradiomics is an open-source python package for the extraction of Radiomics features from medical imaging.
+
+# Space separated list of urls
+screenshoturls 
+
+# 0 or 1: Define if the extension should be enabled after its installation.
+enabled 1


### PR DESCRIPTION
Radiomics provides a 3D Slicer interface to the pyradiomics library.

pyradiomics is an open-source python package for the extraction of Radiomics
features from medical imaging. More at http://pyradiomics.readthedocs.io/en/latest/.