### PR TITLE
Updating Perk Tutor to depend on the Sequences extension.

### DIFF
--- a/PerkTutor.s4ext
+++ b/PerkTutor.s4ext
@@ -7,15 +7,15 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl https://github.com/PerkTutor/PerkTutor.git
-scmrevision 469fb1f
+scmrevision master
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files
 # - The dependencies will be built first
-depends NA
+depends Sequences
 
 # Inner build directory (default is ".")
-build_subdirectory inner-build
+build_subdirectory .
 
 # homepage
 homepage http://www.perktutor.org/


### PR DESCRIPTION
These changes will allow the Perk Tutor extension to depend on the Sequences extensions, including transition from a multi-repository to single repository structure to facilitate this change.

Compare link: https://github.com/PerkTutor/PerkTutor/compare/03d0d6570d225c1b85b46cef2267882effec098e...c6964b7e3d63abd8c4db2f73c96998ccd9d189df.