### PR TITLE
Update IASEM module to address linking errors on release

### DIFF
--- a/IASEM.s4ext
+++ b/IASEM.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl git://github.com/blowekamp/Slicer-IASEM.git
-scmrevision 346a71558368117b61c9b2b26e40568597c23423
+scmrevision f3895471dd01d0340cbed5178dfe7ac27b745090
 
 
 # list dependencies


### PR DESCRIPTION
Address Undefined reference to FactoryRegistration
    Fixed the following error:
    BinShrinkTest.cxx:(.text.startup+0x10a): undefined reference to `itk::itkFactoryRegistration()'