### PR TITLE
BUG: Corrected links to icon and screenshot.

### DIFF
--- a/DatabaseInteractor.s4ext
+++ b/DatabaseInteractor.s4ext
@@ -28,7 +28,7 @@ contributors Clement Mirabel (University of Michigan), Juan Carlos Prieto (UNC)
 category Web System Tools
 
 # url to icon (png, size 128x128 pixels)
-iconurl https://www.slicer.org/wiki/File:DatabaseInteractor_Logo.png
+iconurl https://www.slicer.org/w/images/7/7f/DatabaseInteractor_Logo.png
 
 # Give people an idea what to expect from this code
 #  - Is it just a test or something you stand behind?
@@ -38,7 +38,7 @@ status
 description This extension can interact with online data in a database and local folders.
 
 # Space separated list of urls
-screenshoturls https://www.slicer.org/wiki/File:FullView_DatabaseInteractor.png
+screenshoturls https://www.slicer.org/w/images/1/1f/FullView_DatabaseInteractor.png
 
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 1


### PR DESCRIPTION
I had never noticed the icon was not displaying well in the Slicer Extension Manager because the URL was wrong. Never too late to correct it.