### PR TITLE
Update SkullStripper to fix macOS link error

### DIFF
--- a/SkullStripper.s4ext
+++ b/SkullStripper.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl git://github.com/Slicer/SkullStripper.git
-scmrevision 280121d6d1b5
+scmrevision d1ce9fc
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files


### PR DESCRIPTION
This commit fixes undefined itkFactoryRegistration link error on macOS

See https://github.com/Slicer/SkullStripper/commit/d0701f6ef53987d8e85ab245eda8d63305710f35