### PR TITLE
ENH: Rename Eigen to Eigen3 and update version

### DIFF
--- a/Eigen3.s4ext
+++ b/Eigen3.s4ext
@@ -1,7 +1,7 @@
 # This is source code manager (i.e. svn)
 scm git
-scmurl git://github.com/BRAINSia/eigen.git
-scmrevision aac58c68ef2670ac6da5e690a65c96a442f026b4
+scmurl git://github.com/RLovelett/eigen.git
+scmrevision fb69618f68883359f62fa48108433448bc61fdd2
 # list dependencies
 # - These should be names of other modules that have .s4ext files
 # - The dependencies will be built first


### PR DESCRIPTION
Since the latest version of Eigen provides a config file named
Eigen3Config.cmake, this commit renames the extension to facilitate its
use.

Calling "find_package(Eigen3 REQUIRED CONFIG)" and linking against
"Eigen3::Eigen" are now the only required steps to use Eigen.

Since no extension explicitly depend on Eigen, the renaming will not
have any negative impact. Instead, it will allow to update PortPlacement
extension and fix its build by explicitly adding Eigen3 as a dependency.