### PR TITLE
Update XNATSlicer to fix git revision

### DIFF
--- a/XNATSlicer.s4ext
+++ b/XNATSlicer.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl https://github.com/NrgXnat/XNATSlicer.git
-scmrevision aaedd3e108ae3f07f38aa517b14bc00b86ded170
+scmrevision 2f4bf01beb90d32c7aa23c8b920d6797e36b0c6b
             
 
 # list dependencies


### PR DESCRIPTION
This commit will fix the following error:

```
Cloning into 'XNATSlicer'...

  fatal: reference is not a tree: aaedd3e108ae3f07f38aa517b14bc00b86ded170

  CMake Error at
  XNATSlicer-download-prefix/tmp/XNATSlicer-download-gitclone.cmake:75
  (message):

    Failed to checkout tag: 'aaedd3e108ae3f07f38aa517b14bc00b86ded170'
```