### PR TITLE
ENH: Remove unused and failing "boost" extension

### DIFF
--- a/boost.s4ext
+++ b/boost.s4ext
@@ -1,8 +1,0 @@
-scm git
-scmurl git://gitorious.org/boost/cmake.git
-scmrevision cmake-1.41.0
-
-depends     NA
-build_subdirectory .
-
-homepage http://gitorious.org/boost/cmake


### PR DESCRIPTION
It has been failing with the following error for a while:

```
Cloning into 'boost'...

  fatal: unable to connect to gitorious.org:

  gitorious.org[0: 64.13.172.37]: errno=No error
```