### PR TITLE
Updating extension icon url

### DIFF
--- a/T2mapping.s4ext
+++ b/T2mapping.s4ext
@@ -35,7 +35,7 @@ iconurl     https://github.com/gattia/Slicer-T2mapping/blob/master/T2mapping.png
 status      Calculations work. Im sure improvements to Slicer related code could be improved. 
 
 # One line stating what the module does
-T2mapping creates a T2 Map from an inputed 4D multi-echo MRI. 
+description T2mapping creates a T2 Map from an inputed 4D multi-echo MRI. 
 
 # Space separated list of urls
 

--- a/T2mapping.s4ext
+++ b/T2mapping.s4ext
@@ -1,0 +1,43 @@
+#
+# First token of each non-comment line is the keyword and the rest of the line
+# (including spaces) is the value.
+# - the value can be blank
+#
+
+# This is source code manager (i.e. svn)
+scm git
+scmurl https://github.com/gattia/Slicer-T2mapping
+scmrevision master
+
+# list dependencies
+# - These should be names of other modules that have .s4ext files
+# - The dependencies will be built first
+depends     NA
+
+# Inner build directory (default is .)
+build_subdirectory .
+
+# homepage
+homepage    N/a
+
+# Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
+# For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)
+contributors Anthony Gatti (McMaster/NeuralSeg)
+
+# Match category in the xml description of the module (where it shows up in Modules menu)
+category    Quantification
+
+# url to icon (png, size 128x128 pixels)
+iconurl     https://github.com/gattia/Slicer-T2mapping/blob/master/T2mapping.png
+
+# Give people an idea what to expect from this code
+#  - Is it just a test or something you stand beind?
+status      Calculations work. Im sure improvements to Slicer related code could be improved. 
+
+# One line stating what the module does
+T2mapping creates a T2 Map from an inputed 4D multi-echo MRI. 
+
+# Space separated list of urls
+
+# 0 or 1: Define if the extension should be enabled after its installation.
+enabled 1

--- a/T2mapping.s4ext
+++ b/T2mapping.s4ext
@@ -22,17 +22,17 @@ homepage    N/a
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
 # For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)
-contributors Anthony Gatti (McMaster/NeuralSeg)
+contributors Anthony Gatti (McMaster/NeuralSeg Ltd.)
 
 # Match category in the xml description of the module (where it shows up in Modules menu)
 category    Quantification
 
 # url to icon (png, size 128x128 pixels)
-iconurl     https://github.com/gattia/Slicer-T2mapping/blob/master/T2mapping.png
+iconurl     https://raw.githubusercontent.com/gattia/Slicer-T2mapping/master/T2mapping/Resources/Icons/T2mapping.png
 
 # Give people an idea what to expect from this code
 #  - Is it just a test or something you stand beind?
-status      Calculations work. Im sure improvements to Slicer related code could be improved. 
+status      Calculations work. Im sure improvements to Slicer related code could be made. 
 
 # One line stating what the module does
 description T2mapping creates a T2 Map from an inputed 4D multi-echo MRI. 


### PR DESCRIPTION
After the extension was merged/accepted, I checked it out and the icons/screenshots weren't displaying properly. I have updated the URL for the icon in the T2mapping.s4ext, as well as within the files of the program repository. 