### PR TITLE
ADD: Add SlicerCaseIterator to 4.8 branch

### DIFF
--- a/SlicerCaseIterator.s4ext
+++ b/SlicerCaseIterator.s4ext
@@ -1,0 +1,44 @@
+#
+# First token of each non-comment line is the keyword and the rest of the line
+# (including spaces) is the value.
+# - the value can be blank
+#
+
+# This is source code manager (i.e. svn)
+scm git
+scmurl https://github.com/JoostJM/SlicerCaseIterator.git
+scmrevision master
+
+# list dependencies
+# - These should be names of other modules that have .s4ext files
+# - The dependencies will be built first
+depends NA
+
+# Inner build directory (default is ".")
+build_subdirectory .
+
+# homepage
+homepage https://www.slicer.org/wiki/Documentation/Nightly/Extensions/SlicerCaseIterator
+
+# Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
+# For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)
+contributors Joost van Griethuysen (NKI)
+
+# Match category in the xml description of the module (where it shows up in Modules menu)
+category Utilities
+
+# url to icon (png, size 128x128 pixels)
+iconurl https://raw.githubusercontent.com/JoostJM/SlicerCaseIterator/master/SlicerCaseIterator.png
+
+# Give people an idea what to expect from this code
+#  - Is it just a test or something you stand behind?
+status beta
+
+# One line stating what the module does
+description Simple scripted module that allows you to iterate through a set of cases defined in a csv-file.
+
+# Space separated list of urls
+screenshoturls https://raw.githubusercontent.com/JoostJM/SlicerCaseIterator/master/SlicerCaseIterator-Screenshot.png
+
+# 0 or 1: Define if the extension should be enabled after its installation.
+enabled 1


### PR DESCRIPTION
Add the slicer case iterator extension description to the 4.8 branch.
Original PR integrating this extension into the nightly build can be found at
https://github.com/Slicer/ExtensionsIndex/pull/1505