### PR TITLE
update SlicerOpenCV hash

### DIFF
--- a/SlicerOpenCV.s4ext
+++ b/SlicerOpenCV.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl git://github.com/SBU-BMI/SlicerOpenCV.git
-scmrevision master
+scmrevision fd72c6842c72425b7ca31588ddfa9930e0f46f75
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files


### PR DESCRIPTION
the latest version of SlicerOpenCV does not build on macOS due to a
compiler issue, as discussed in https://github.com/SBU-BMI/SlicerOpenCV/issues/47

@tdiprima FYI