### PR TITLE
Add Osteotomy Planner Extension

### DIFF
--- a/OsteotomyPlanner.s4ext
+++ b/OsteotomyPlanner.s4ext
@@ -1,0 +1,44 @@
+#
+# First token of each non-comment line is the keyword and the rest of the line
+# (including spaces) is the value.
+# - the value can be blank
+#
+
+# This is source code manager (i.e. svn)
+scm git
+scmurl git://github.com/KitwareMedical/OsteotomyPlanner.git
+scmrevision 8258e52
+
+# list dependencies
+# - These should be names of other modules that have .s4ext files
+# - The dependencies will be built first
+depends NA
+
+# Inner build directory (default is ".")
+build_subdirectory inner-build
+
+# homepage
+homepage https://github.com/KitwareMedical/OsteotomyPlanner/wiki
+
+# Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
+# For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)
+contributors Sam Horvath (Kitware Inc.), Johan Andruejol (Kitware Inc.)
+
+# Match category in the xml description of the module (where it shows up in Modules menu)
+category Osteotomy Planning
+
+# url to icon (png, size 128x128 pixels)
+iconurl https://raw.githubusercontent.com/KitwareMedical/OsteotomyPlanner/master/Planner/Resources/Icons/Planner.png
+
+# Give people an idea what to expect from this code
+#  - Is it just a test or something you stand behind?
+status In development
+
+# One line stating what the module does
+description Osteotomy Planner is an extension designed to help the planning of bone surgeries.
+
+# Space separated list of urls
+screenshoturls https://raw.githubusercontent.com/KitwareMedical/OsteotomyPlanner/master/Screenshots/Screenshot.jpg
+
+# 0 or 1: Define if the extension should be enabled after its installation.
+enabled 1


### PR DESCRIPTION
The Osteotomy Planner is a 3DSlicer extension for arranging, cutting
and bending closed surface mesh models that represent bone structures.
It can be used for the planning of surgical procedures and analysis
of the resulting structures.