### PR TITLE
EHN: Added SlicerProstateAblation extension.

### DIFF
--- a/SlicerProstateAblation.s4ext
+++ b/SlicerProstateAblation.s4ext
@@ -1,0 +1,44 @@
+#
+# First token of each non-comment line is the keyword and the rest of the line
+# (including spaces) is the value.
+# - the value can be blank
+#
+
+# This is source code manager (i.e. svn)
+scm git
+scmurl https://github.com/SlicerProstate/SlicerProstateAblation.git
+scmrevision master
+
+# list dependencies
+# - These should be names of other modules that have .s4ext files
+# - The dependencies will be built first
+depends SlicerDevelopmentToolbox SlicerZFrameRegistration
+
+# Inner build directory (default is ".")
+build_subdirectory .
+
+# homepage
+homepage https://github.com/SlicerProstate/SlicerProstateAblation
+
+# Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
+# For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)
+contributors Longquan Chen(SPL), Christian Herz(SPL), Junichi Tokuda(SPL)
+
+# Match category in the xml description of the module (where it shows up in Modules menu)
+category IGT
+
+# url to icon (png, size 128x128 pixels)
+iconurl https://raw.githubusercontent.com/SlicerProstate/SlicerProstateAblation/master/SlicerProstateAblation.png
+
+# Give people an idea what to expect from this code
+#  - Is it just a test or something you stand behind?
+status 
+
+# One line stating what the module does
+description This extension provides support for prostate cryoablation.
+
+# Space separated list of urls
+screenshoturls https://raw.githubusercontent.com/SlicerProstate/SlicerProstateAblation/master/Screenshots/Slicelet.png
+
+# 0 or 1: Define if the extension should be enabled after its installation.
+enabled 1


### PR DESCRIPTION
SlicerProstateAblation is a 3D Slicer extension designed to support the workflow of the in-bore MRI-guided therapies.  SlicerProstateAblation was developed and tested to support transperineal prostate ablation procedures in the Advanced Multimodality Image Guided Operating (AMIGO) at the Brigham and Women's Hospital, Boston. Its applicability to other types of procedures has not been evaluated.
[SlicerProstateAblation](https://github.com/SlicerProstate/SlicerProstateAblation)