### PR TITLE
SlicerVMTK source set to github.com/vmtk

### DIFF
--- a/SlicerVMTK.s4ext
+++ b/SlicerVMTK.s4ext
@@ -6,8 +6,8 @@
 
 # This is source code manager (i.e. svn)
 scm git
-scmurl https://github.com/jcfr/SlicerExtension-VMTK
-scmrevision 5013f532b398f7c9a983bdf65a175ec41ce3292a
+scmurl https://github.com/vmtk/SlicerExtension-VMTK
+scmrevision master
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files


### PR DESCRIPTION
The remote source for SlicerVMTK.s4ext was previously set to a personal repository. Fixes have been made in the GitHub.com/vmtk/SlicerExtension-VMTK.git source, and so it can be the source for the extension's code.
This pull request changes the source code manager lines in SlicerVMTK.git to:
scmurl https://github.com/vmtk/SlicerExtension-VMTK
scmrevision master