### PR TITLE
ENH: Update Eigen3

### DIFF
--- a/Eigen3.s4ext
+++ b/Eigen3.s4ext
@@ -1,7 +1,7 @@
 # This is source code manager (i.e. svn)
 scm git
-scmurl git://github.com/RLovelett/eigen.git
-scmrevision fb69618f68883359f62fa48108433448bc61fdd2
+scmurl git://github.com/eigenteam/eigen-git-mirror
+scmrevision branches/3.3
 # list dependencies
 # - These should be names of other modules that have .s4ext files
 # - The dependencies will be built first


### PR DESCRIPTION
Since 29.12.2017 Eigen offers an official mirror in github:
https://github.com/eigenteam/eigen-git-mirror

This update Eigen3 to the latest stable branch 3.3.5
using that mirror