### PR TITLE
Add SlicerWMA python (installer only) extension

### DIFF
--- a/SlicerWMA.ext
+++ b/SlicerWMA.ext
@@ -1,0 +1,25 @@
+scm git
+scmurl https://github.com/SlicerDMRI/whitematteranalysis
+scmrevision master
+
+depends NA
+
+build_subdirectory inner-build
+
+homepage http://slicerdmri.github.io
+
+contributors Lauren O'Donnell, Fan Zhang (Brigham & Women's Hospital), and others.
+
+category Diffusion
+
+iconurl https://gist.githubusercontent.com/ihnorton/f860e58c99015a6b1a3b04cc4c772412/raw/b2a440420cc01630b339c52b3feaa2744eae7039/SlicerWMA.png
+
+status WIP
+
+# One line stating what the module does
+description SlicerWMA currently provides the WhiteMatterAnalysis (https://github.com/SlicerDMRI/whitematteranalysis) python package and dependencies installed within Slicer's Python environment.
+
+# Space separated list of urls
+
+# 0 or 1: Define if the extension should be enabled after its installation.
+enabled 0

--- a/SlicerWMA.ext
+++ b/SlicerWMA.ext
@@ -1,18 +1,18 @@
 scm git
-scmurl https://github.com/SlicerDMRI/whitematteranalysis
+scmurl https://github.com/SlicerDMRI/SlicerWMA
 scmrevision master
 
 depends NA
 
 build_subdirectory inner-build
 
-homepage http://slicerdmri.github.io
+homepage https://github.com/SlicerDMRI/whitematteranalysis
 
 contributors Lauren O'Donnell, Fan Zhang (Brigham & Women's Hospital), and others.
 
 category Diffusion
 
-iconurl https://gist.githubusercontent.com/ihnorton/f860e58c99015a6b1a3b04cc4c772412/raw/b2a440420cc01630b339c52b3feaa2744eae7039/SlicerWMA.png
+iconurl https://raw.githubusercontent.com/SlicerDMRI/SlicerWMA/master/SlicerWMA.png
 
 status WIP
 

--- a/SlicerWMA.ext
+++ b/SlicerWMA.ext
@@ -10,7 +10,7 @@ homepage https://github.com/SlicerDMRI/whitematteranalysis
 
 contributors Lauren O'Donnell, Fan Zhang (Brigham & Women's Hospital), and others.
 
-category Diffusion
+category Libraries
 
 iconurl https://raw.githubusercontent.com/SlicerDMRI/SlicerWMA/master/SlicerWMA.png
 


### PR DESCRIPTION
This is not a "functional" extension yet: all it does is package [WhiteMatterAnalysis](https://github.com/SlicerDMRI/whitematteranalysis) and dependencies. We want to add it now in order to:
- use the package with full dependencies already installed, within Slicer's python. This is for a potentially low-connectivity environment (want to be able to hand out self-contained extension .tar.gz locally if needed)

- do further development/testing of (scripted) wrapper tooling on multiple platforms without setting up a full build environment

The extension logo clearly marks as WIP:

![logo](https://gist.githubusercontent.com/ihnorton/f860e58c99015a6b1a3b04cc4c772412/raw/b2a440420cc01630b339c52b3feaa2744eae7039/SlicerWMA.png)

