### PR TITLE
ENH: Update ErodeDilateLabel extension

### DIFF
--- a/ErodeDilateLabel.s4ext
+++ b/ErodeDilateLabel.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl https://github.com/tokjun/ErodeDilateLabel.git
-scmrevision 0fc1f7c
+scmrevision 3f4146ddaa712c8f0a8418f49b2624a1dd6fd20a
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files


### PR DESCRIPTION
This updates the ErodeDilateLabel extension to tokjun/ErodeDilateLabel@3f4146ddaa712c8f0a8418f49b2624a1dd6fd20a.