### PR TITLE
Add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,28 @@
+# Update an existing extension
+
+You can delete this whole template and just describe which exension is updated and optionally tell us in a sentence what has been changed.
+
+To make extension updates easier in the future, you may consider replacing specific git hash in your s4ext file by a branch name (for example: `master` or `release` for nightly version; `(majorVersion).(minorVersion)` such as `4.10` for stable Slicer version).
+
+# Submitting a new extension
+
+Thank you very much for considering sharing your extension with the Slicer community.
+
+To make sure users can find your extension, understand what it is intended for and how to use it, please complete the checklist below. You do not need to complete all the item by the time you submit the pull request, but most likely the changes will only be merged if all the tasks are done.
+
+- [ ] Extension has a reasonable name (not too general, not too narrow, suggests what the extension is for)
+- [ ] Repository name is Slicer+ExtensionName
+- [ ] Extension description summarizes in 1-2 sentences what the extension is usable (should be understandable for non-experts)
+- [ ] Extension URL and revision (scmurl, scmrevision) is correct, consider using a branch name (master, release, ...) instead of a specific git has to avoid re-submitting pull request whenever the extension is updated
+- [ ] Extension icon URL is correct
+- [ ] Screenshot URLs (screenshoturls) are correct, contains at least one
+- [ ] Homepage URL points to valid webpage containing the followings:
+  - [ ] Extension name
+  - [ ] Short description: 1-2 sentences, which summarizes what the extension is usable for
+  - [ ] At least one nice, informative image, that illustrates what the extension can do. It may be a screenshot.
+  - [ ] Description of contained modules: at one sentence for each module
+  - [ ] Tutorial: step-by-step description of at least the most typical use case, include a few screenshots, provide download links to sample input data set
+
+See more information about the submission process on the Slicer wiki: https://www.slicer.org/wiki/Documentation/Nightly/Developers/Tutorials/BuildTestPackageDistributeExtensions
+
+If you have any questions or comments then please describe them here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 # Update an existing extension
 
-You can delete this whole template and just describe which exension is updated and optionally tell us in a sentence what has been changed.
+You can delete this whole template and just describe which extension is updated and optionally tell us in a sentence what has been changed.
 
 To make extension updates easier in the future, you may consider replacing specific git hash in your s4ext file by a branch name (for example: `master` or `release` for nightly version; `(majorVersion).(minorVersion)` such as `4.10` for stable Slicer version).
 
@@ -16,7 +16,7 @@ To make sure users can find your extension, understand what it is intended for a
 - [ ] Extension URL and revision (scmurl, scmrevision) is correct, consider using a branch name (master, release, ...) instead of a specific git has to avoid re-submitting pull request whenever the extension is updated
 - [ ] Extension icon URL is correct
 - [ ] Screenshot URLs (screenshoturls) are correct, contains at least one
-- [ ] Homepage URL points to valid webpage containing the followings:
+- [ ] Homepage URL points to valid webpage containing the following:
   - [ ] Extension name
   - [ ] Short description: 1-2 sentences, which summarizes what the extension is usable for
   - [ ] At least one nice, informative image, that illustrates what the extension can do. It may be a screenshot.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-# Update an existing extension
+# Updating an extension
 
 You can delete this whole template and just describe which extension is updated and optionally tell us in a sentence what has been changed.
 

--- a/scripts/check_filenames.sh
+++ b/scripts/check_filenames.sh
@@ -12,7 +12,7 @@ cd $root_dir
 msg="Looking for unexpected files"
 echo "$msg"
 
-unexpected_files=$(find . -mindepth 1 \( -type d \( -path ./.circleci -o -path ./.git -o -path ./scripts \) -o -type f \( -name README.md -o -name "*.s4ext"  \)  \)  -prune -o -print)
+unexpected_files=$(find . -mindepth 1 \( -type d \( -path ./.circleci -o -path ./.idea -o -path ./.github -o -path ./.git -o -path ./scripts \) -o -type f \( -name README.md -o -name "*.s4ext"  \)  \)  -prune -o -print)
 for unexpected_file in $unexpected_files; do
   echo $unexpected_file
 done


### PR DESCRIPTION
Add a pull request template with instructions for what to do for new extensions and for extension updates. The template file content populates the description field in all new pull requests.

I've tried adding separate templates for extension updates / new extensions but then GitHub did not offer either of them automatically. I had to create a URL manually that contained a template name argument.
