### PR TITLE
Change stable version of SlicerOpenIGTLink to use master branch

### DIFF
--- a/SlicerOpenIGTLink.s4ext
+++ b/SlicerOpenIGTLink.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl git://github.com/openigtlink/SlicerOpenIGTLink.git
-scmrevision 4.10
+scmrevision master
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files


### PR DESCRIPTION
With integration of video streaming classes in stable, SlicerOpenIGTLink can now be built using master branch.