### PR TITLE
Submitting a new extension LesionSimulatorExtension.

### DIFF
--- a/LesionSimulator.s4ext
+++ b/LesionSimulator.s4ext
@@ -6,7 +6,7 @@
 
 # This is source code manager (i.e. svn)
 scm git
-scmurl https://github.com/CSIM-Toolkits/LesionSimulatorExtension.git
+scmurl https://github.com/CSIM-Toolkits/Slicer-LesionSimulatorExtension.git
 scmrevision master
 
 # list dependencies

--- a/LesionSimulator.s4ext
+++ b/LesionSimulator.s4ext
@@ -1,0 +1,44 @@
+#
+# First token of each non-comment line is the keyword and the rest of the line
+# (including spaces) is the value.
+# - the value can be blank
+#
+
+# This is source code manager (i.e. svn)
+scm git
+scmurl https://github.com/CSIM-Toolkits/LesionSimulatorExtension.git
+scmrevision master
+
+# list dependencies
+# - These should be names of other modules that have .s4ext files
+# - The dependencies will be built first
+depends NA
+
+# Inner build directory (default is ".")
+build_subdirectory .
+
+# homepage
+homepage https://www.slicer.org/wiki/Documentation/Nightly/Extensions/LesionSimulator
+
+# Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
+# For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)
+contributors Antonio Carlos da Silva Senra Filho (University of Sao Paulo), Fabrício Henrique Simozo (University of Sao Paulo)
+
+# Match category in the xml description of the module (where it shows up in Modules menu)
+category Simulation
+
+# url to icon (png, size 128x128 pixels)
+iconurl https://www.slicer.org/w/images/d/d5/LesionSimulator-logo.png
+
+# Give people an idea what to expect from this code
+#  - Is it just a test or something you stand behind?
+status 
+
+# One line stating what the module does
+description This extension offer a set of tools for brain lesion simulation, based on MRI images. At moment, the modules MS Lesion Simulator and MS Longitudinal Lesion Simulator are available, where it can simulate both baseline scan lesion volumes (given a lesion load) and longitudinal image simulations, respectively. In summary, a statistical lesion database is generated based on a set of manual lesion mark-ups, being non-linearly registered to MNI152 space (isotropic 1mm of voxel resolution). Using a small set of parameters (lesion load, lesion homogeneity, lesion intensity indenpendence and lesion variability), it is possible to generate a broad range of MS lesions patterns in multimodal MRI imaging techniques (at moment, T1, T2, T2-FLAIR, PD, DTI-FA and DTI-ADC images are provided). For more details about this project, please see the original paper (DOI: 10.1088/2057-1976/ab08fc ) and the wiki page.
+
+# Space separated list of urls
+screenshoturls https://www.slicer.org/w/images/5/55/LesionLoad_2mL.png https://www.slicer.org/w/images/f/f5/LesionLoad_5mL.png https://www.slicer.org/w/images/f/f5/LesionLoad_40mL.png https://www.slicer.org/w/images/f/f0/3DLesionsOverlay.png https://www.slicer.org/w/images/1/1a/MNI152_orig.png https://www.slicer.org/w/images/e/ef/MNI152_lesionload40mL.png https://www.slicer.org/w/images/c/c9/MNI152_orig_sag.png https://www.slicer.org/w/images/a/aa/MNI152_lesionload40mL_sag.png
+
+# 0 or 1: Define if the extension should be enabled after its installation.
+enabled 1


### PR DESCRIPTION
# Submitting a new extension

Multiple Sclerosis multimodal lesion simulation tool (MS-MIST)

This extension offers a set of tools for brain lesion simulation, based on MRI images. At the moment, the modules MS Lesion Simulator and MS Longitudinal Lesion Simulator are available, where it can simulate both baseline scan lesion volumes (given a lesion load) and longitudinal image simulations, respectively. In summary, a statistical lesion database is generated based on a set of manual lesion mark-ups, being non-linearly registered to MNI152 space (isotropic 1mm of voxel resolution). Using a small set of parameters (lesion load, lesion homogeneity, lesion intensity independence and lesion variability), it is possible to generate a broad range of MS lesions patterns in multimodal MRI imaging techniques (at moment, T1, T2, T2-FLAIR, PD, DTI-FA and DTI-ADC images are provided). For more details about this project, please see the original paper (DOI: 10.1088/2057-1976/ab08fc ) and the wiki page.