### PR TITLE
ENH: Add CUDAProbe extension [master]

### DIFF
--- a/CUDAProbe.s4ext
+++ b/CUDAProbe.s4ext
@@ -1,0 +1,44 @@
+#
+# First token of each non-comment line is the keyword and the rest of the line
+# (including spaces) is the value.
+# - the value can be blank
+#
+
+# This is source code manager (i.e. svn)
+scm git
+scmurl https://github.com/gregsharp/Slicer-CUDAProbe.git
+scmrevision 011d01b24d69fbdcab600ee705e643516953fe0b
+
+# list dependencies
+# - These should be names of other modules that have .s4ext files
+# - The dependencies will be built first
+depends NA
+
+# Inner build directory (default is ".")
+build_subdirectory .
+
+# homepage
+homepage https://github.com/gregsharp/Slicer-CUDAProbe
+
+# Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
+# For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)
+contributors Gregory Sharp (Massachusetts General Hospital)
+
+# Match category in the xml description of the module (where it shows up in Modules menu)
+category Developer Tools
+
+# url to icon (png, size 128x128 pixels)
+iconurl https://raw.githubusercontent.com/gregsharp/Slicer-CUDAProbe/master/CUDAProbe.png
+
+# Give people an idea what to expect from this code
+#  - Is it just a test or something you stand behind?
+status Work in progress
+
+# One line stating what the module does
+description This extension queries your computer for its CUDA capabilities.  It also serves as an example of how to use CUDA in your Slicer Extension.
+
+# Space separated list of urls
+screenshoturls https://raw.githubusercontent.com/gregsharp/Slicer-CUDAProbe/master/CUDAProbe-screenshot.png
+
+# 0 or 1: Define if the extension should be enabled after its installation.
+enabled 1


### PR DESCRIPTION
Description:
This extension queries your computer for its CUDA capabilities.  It also
serves as an example of how to use CUDA in your Slicer Extension.

Contributors:
Gregory Sharp (Massachusetts General Hospital)
