### PR TITLE
Added ModelCropper.s4ext

### DIFF
--- a/ModelCropper.s4ext
+++ b/ModelCropper.s4ext
@@ -1,0 +1,44 @@
+#
+# First token of each non-comment line is the keyword and the rest of the line
+# (including spaces) is the value.
+# - the value can be blank
+#
+
+# This is source code manager (i.e. svn)
+scm git
+scmurl git://github.com/sebastianandress/Slicer-ModelCropper.git
+scmrevision master
+
+# list dependencies
+# - These should be names of other modules that have .s4ext files
+# - The dependencies will be built first
+depends NA
+
+# Inner build directory (default is ".")
+build_subdirectory .
+
+# homepage
+homepage https://github.com/sebastianandress/Slicer-ModelCropper
+
+# Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
+# For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)
+contributors Sebastian Andress (LMU Munich)
+
+# Match category in the xml description of the module (where it shows up in Modules menu)
+category Surface Models
+
+# url to icon (png, size 128x128 pixels)
+iconurl https://github.com/sebastianandress/Slicer-ModelCropper/raw/master/ModelCropper.png
+
+# Give people an idea what to expect from this code
+#  - Is it just a test or something you stand behind?
+status 
+
+# One line stating what the module does
+Simple extension that crops a surface model along a roi box. It uses vtkBooleanOperationPolyDataFilter for the cropping.
+
+# Space separated list of urls
+screenshoturls https://github.com/sebastianandress/Slicer-ModelCropper/raw/master/Screenshots/Screenshot%20Model%20Cropper.png
+
+# 0 or 1: Define if the extension should be enabled after its installation.
+enabled 1


### PR DESCRIPTION
A simple extension allowing to crop a model along a roi annotation. Applied transformations are respected.

- [x] Extension has a reasonable name (not too general, not too narrow, suggests what the extension is for)
- [x] Repository name is Slicer+ExtensionName
- [x] Extension description summarizes in 1-2 sentences what the extension is usable (should be understandable for non-experts)
- [x] Extension URL and revision (scmurl, scmrevision) is correct, consider using a branch name (master, release, ...) instead of a specific git has to avoid re-submitting pull request whenever the extension is updated
- [x] Extension icon URL is correct
- [x] Screenshot URLs (screenshoturls) are correct, contains at least one
- [x] Homepage URL points to valid webpage containing the following:
  - [x] Extension name
  - [x] Short description: 1-2 sentences, which summarizes what the extension is usable for
  - [x] At least one nice, informative image, that illustrates what the extension can do. It may be a screenshot.
  - [x] Description of contained modules: at one sentence for each module
  - [x] Tutorial: step-by-step description of at least the most typical use case, include a few screenshots, provide download links to sample input data set
  - [ ] Publication: link to publication and/or to PubMed reference (if available)
  - [x] License: We suggest you use a permissive license that includes patent and contribution clauses.  This will help protect developers and ensure the code remains freely available.  We suggest you use the [Slicer License](https://github.com/Slicer/Slicer/blob/master/License.txt) or the [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0). Always mention in your README file the license you have chosen.  If you choose a different license, explain why to the extension maintainers. Depending on the license we may not be able to host your work.
Read [here](https://opensource.guide/legal/#which-open-source-license-is-appropriate-for-my-project) to learn more about licenses.
