### PR TITLE
ENH:  Add check to verify that the listed scm is not "local"

### DIFF
--- a/scripts/check_description_files.py
+++ b/scripts/check_description_files.py
@@ -70,6 +70,11 @@ def check_scmurl_syntax(extension_name, metadata):
             extension_name, check_name,
             "scmurl scheme is '%s' but it should by any of %s" % (scheme, supported_schemes))
 
+@require_metadata_key("scm")
+def check_scm_notlocal(extension_name, metadata):
+    check_name = "check_scm_notlocal"
+    if metadata["scm"] == "local":
+        raise ExtensionCheckError(extension_name, check_name, "scm cannot be local")
 
 @require_metadata_key("scmurl")
 @require_metadata_key("scm")
@@ -146,6 +151,7 @@ def main():
     if not checks:
         checks = [
             check_scmurl_syntax,
+            check_scm_notlocal,
         ]
 
     total_failure_count = 0


### PR DESCRIPTION
Adds a check to make sure that the scm tag is not "local"  which won't work on the factory systems.

See: https://github.com/Slicer/ExtensionsIndex/commit/ad2b02223a4e7a3a2070f821cad52daacc91390c

Also, previously the check_scmurl_syntax check was only done when we weren't doing the repo name check, which doesn't seem right.  With this commit, the repo check is done based on the parameters, and then the scmurl check is done every time.