### PR TITLE
Add NVIDIA Clara AI-Assisted Annotation Extension to Slicer-4.11

### DIFF
--- a/NvidiaAIAssistedAnnotation.s4ext
+++ b/NvidiaAIAssistedAnnotation.s4ext
@@ -1,0 +1,44 @@
+#
+# First token of each non-comment line is the keyword and the rest of the line
+# (including spaces) is the value.
+# - the value can be blank
+#
+
+# This is source code manager (i.e. svn)
+scm git
+scmurl https://github.com/NVIDIA/ai-assisted-annotation-client.git
+scmrevision master
+
+# list dependencies
+# - These should be names of other modules that have .s4ext files
+# - The dependencies will be built first
+depends NA
+
+# Inner build directory (default is ".")
+build_subdirectory slicer-plugin
+
+# homepage
+homepage https://github.com/NVIDIA/ai-assisted-annotation-client/tree/master/slicer-plugin
+
+# Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
+# For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)
+contributors Sachidanand Alle (NVIDIA)
+
+# Match category in the xml description of the module (where it shows up in Modules menu)
+category Segmentation
+
+# url to icon (png, size 128x128 pixels)
+iconurl https://raw.githubusercontent.com/NVIDIA/ai-assisted-annotation-client/master/slicer-plugin/NvidiaAIAssistedAnnotation.png
+
+# Give people an idea what to expect from this code
+#  - Is it just a test or something you stand behind?
+status 
+
+# One line stating what the module does
+description This extension offers automatic segmentation using NVIDIA AI-Assisted Annotation framework (Powered by the Clara Train SDK).
+
+# Space separated list of urls
+screenshoturls https://raw.githubusercontent.com/NVIDIA/ai-assisted-annotation-client/master/slicer-plugin/snapshot.png
+
+# 0 or 1: Define if the extension should be enabled after its installation.
+enabled 1


### PR DESCRIPTION
This adds Nvidia's AI-assisted annotation (powered by Clara Train SDK) automatic deep learning based segmenter to Segment editor.

It will be functional once this pull request is merged, too:
https://github.com/NVIDIA/ai-assisted-annotation-client/pull/43