### PR TITLE
ENH: Add SlicerCIP extension [master]

### DIFF
--- a/SlicerCIP.s4ext
+++ b/SlicerCIP.s4ext
@@ -1,0 +1,44 @@
+#
+# First token of each non-comment line is the keyword and the rest of the line
+# (including spaces) is the value.
+# - the value can be blank
+#
+
+# This is source code manager (i.e. svn)
+scm git
+scmurl https://github.com/acil-bwh/SlicerCIP
+scmrevision feb66c0cc201dbbb2d36f164f1edb8857c5a37c4
+
+# list dependencies
+# - These should be names of other modules that have .s4ext files
+# - The dependencies will be built first
+depends NA
+
+# Inner build directory (default is ".")
+build_subdirectory inner-build
+
+# homepage
+homepage http://www.chestimagingplatform.org
+
+# Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
+# For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)
+contributors Applied Chest Imaging Laboratory, Brigham and Women's Hospital
+
+# Match category in the xml description of the module (where it shows up in Modules menu)
+category Chest Imaging Platform
+
+# url to icon (png, size 128x128 pixels)
+iconurl https://raw.githubusercontent.com/acil-bwh/SlicerCIP/4.5/Resources/SlicerCIPLogo.png
+
+# Give people an idea what to expect from this code
+#  - Is it just a test or something you stand behind?
+status Alpha
+
+# One line stating what the module does
+description Chest Imaging Platform is an extension for quantitative CT imaging biomarkers for lung diseases. This work is funded by the National Heart, Lung, And Blood Institute of the National  Institutes of Health under Award Number R01HL116931. The content is solely the responsibility of the authors and does not necessarily represent the official views of the National Institutes of Health.
+
+# Space separated list of urls
+screenshoturls https://raw.githubusercontent.com/acil-bwh/SlicerCIP/4.5/Resources/Screenshot1.png https://raw.githubusercontent.com/acil-bwh/SlicerCIP/4.5/Resources/Screenshot2.png
+
+# 0 or 1: Define if the extension should be enabled after its installation.
+enabled 1


### PR DESCRIPTION
Description:
Chest Imaging Platform is an extension for quantitative CT imaging
biomarkers for lung diseases. This work is funded by the National Heart,
Lung, And Blood Institute of the National  Institutes of Health under
Award Number R01HL116931. The content is solely the responsibility of
the authors and does not necessarily represent the official views of the
National Institutes of Health.

Contributors:
Applied Chest Imaging Laboratory, Brigham and Women's Hospital
