### PR TITLE
Update PETTumorSegmentation.s4ext

### DIFF
--- a/PETTumorSegmentation.s4ext
+++ b/PETTumorSegmentation.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl https://github.com/QIICR/PETTumorSegmentation.git
-scmrevision master
+scmrevision 4.10
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files


### PR DESCRIPTION
update extension file to point to the PETTumorSegmentation extension's branch for Slicer 4.10