### PR TITLE
Update PET-IndiC.s4ext

### DIFF
--- a/PET-IndiC.s4ext
+++ b/PET-IndiC.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl https://github.com/QIICR/PET-IndiC.git
-scmrevision master
+scmrevision 4.10
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files


### PR DESCRIPTION
update extension file to point to the extension's branch for Slicer 4.10