### PR TITLE
Update PETLiverUptakeMeasurement.s4ext

### DIFF
--- a/PETLiverUptakeMeasurement.s4ext
+++ b/PETLiverUptakeMeasurement.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl https://github.com/QIICR/PETLiverUptakeMeasurement
-scmrevision master
+scmrevision 4.10
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files


### PR DESCRIPTION
update extension index file to point to the extension's software branch for Slicer 4.10