### PR TITLE
update dcmqi to use v1.2.2 instead of master

### DIFF
--- a/DCMQI.s4ext
+++ b/DCMQI.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl git://github.com/QIICR/dcmqi.git
-scmrevision master
+scmrevision v1.2.2
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files


### PR DESCRIPTION
Past v1.2.2, dcmqi will be built against DCMTK 3.6.5, and will use SNOMED SCT codes, but Slicer PR to upgrade DCMTK is not merged yet (see https://github.com/Slicer/Slicer/pull/1308).