### PR TITLE
update dcmqi tag in 4.10

### DIFF
--- a/DCMQI.s4ext
+++ b/DCMQI.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl git://github.com/QIICR/dcmqi.git
-scmrevision master
+scmrevision v1.2.2
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files


### PR DESCRIPTION
Past version v1.2.2 dcmqi will be using DCMTK 3.6.5, and will not be backwards compatible with the erlier DCMTK releases due to the switch from SNOMED SRT to SCT codes in DICOM. SCT codes are not present in the version of DCMTK used by dcmqi before upgrade to 3.6.5.