### PR TITLE
ENH: Add Thickness Mapping extension

### DIFF
--- a/ABL-BoneThickness.s4ext
+++ b/ABL-BoneThickness.s4ext
@@ -1,0 +1,36 @@
+# This is source code manager (i.e. svn)
+scm git
+scmurl https://github.com/Auditory-Biophysics-Lab/SlicerBoneThicknessMappingExtension
+scmrevision 9c754f3e68b484e7d0e76b38d827fa75028fd7f4
+
+# list dependencies
+# - These should be names of other modules that have .s4ext files
+# - The dependencies will be built first
+depends NA
+
+# Inner build directory (default is ".")
+build_subdirectory .
+
+# homepage
+homepage https://github.com/Auditory-Biophysics-Lab/SlicerBoneThicknessMappingExtension
+
+# Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
+contributors Evan Simpson (Western University)
+
+# Match category in the xml description of the module (where it shows up in Modules menu)
+category Shape Analysis
+
+# url to icon (png, size 128x128 pixels)
+iconurl https://github.com/Auditory-Biophysics-Lab/SlicerBoneThicknessMappingExtension/blob/master/BoneThicknessMapping/Resources/Icons/icon128.png?raw=true
+
+# Give people an idea what to expect from this code
+status beta
+
+# One line stating what the module does
+description This module calculates and visualizes bone thickness of a volume using VTK ray-casting
+
+# Space separated list of urls
+screenshoturls http://www.slicer.org/slicerWiki/images/0/0b/Slicer4-ABLBoneThickness-GUI.png
+
+# 0 or 1: Define if the extension should be enabled after its installation.
+enabled 1

--- a/ABL-BoneThickness.s4ext
+++ b/ABL-BoneThickness.s4ext
@@ -30,7 +30,7 @@ status beta
 description This module calculates and visualizes bone thickness of a volume using VTK ray-casting
 
 # Space separated list of urls
-screenshoturls http://www.slicer.org/slicerWiki/images/0/0b/Slicer4-ABLBoneThickness-GUI.png
+screenshoturls https://github.com/Auditory-Biophysics-Lab/SlicerBoneThicknessMappingExtension/blob/master/Screenshot.PNG?raw=true
 
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 1

--- a/ABL-BoneThickness.s4ext
+++ b/ABL-BoneThickness.s4ext
@@ -1,7 +1,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl https://github.com/Auditory-Biophysics-Lab/SlicerBoneThicknessMappingExtension
-scmrevision 9c754f3e68b484e7d0e76b38d827fa75028fd7f4
+scmrevision master
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files


### PR DESCRIPTION
## Description:

This extension calculates the bone thickness of a volume and visualizes it with a gradient map overlay on the rendered volume.

## Contributors:

Evan Simpson (Western University)

# TODO list for submitting a new extension

- [x] Extension has a reasonable name
- [x] Repository name is Slicer+ExtensionName
- [x] Repository is associated with `3d-slicer-extension` GitHub topic
- [x] Extension description summarizes in 1-2 sentences what the extension is usable
- [x] Extension URL and revision (scmurl, scmrevision) is correct
- [x] Extension icon URL is correct
- [x] Screenshot URLs (screenshoturls) are correct, contains at least one
- [x] Homepage URL points to valid webpage containing the following:
  - [x] Extension name
  - [x] Short description: 1-2 sentences, which summarizes what the extension is usable for
  - [x] At least one nice, informative image, that illustrates what the extension can do. It may be a screenshot.
  - [x] Description of contained modules: at one sentence for each module
  - [x] Tutorial: step-by-step description of at least the most typical use case, include a few screenshots, provide download links to sample input data set
  - [ ] Publication: link to publication and/or to PubMed reference (if available)
  - [x] BSD-3-Clause License