### PR TITLE
DOC: Fix homepage URL for TorchIO extension

### DIFF
--- a/TorchIO.s4ext
+++ b/TorchIO.s4ext
@@ -18,7 +18,7 @@ depends NA
 build_subdirectory .
 
 # homepage
-homepage https://www.slicer.org/wiki/Documentation/Nightly/Extensions/TorchIO
+homepage https://torchio.readthedocs.io/slicer.html
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
 # For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)


### PR DESCRIPTION
This makes this file fully consistent with CMakeLists.txt in the SlicerTorchIO repo: https://github.com/fepegar/SlicerTorchIO/blob/master/CMakeLists.txt