### PR TITLE
Update OpenDose3D.s4ext

### DIFF
--- a/OpenDose3D.s4ext
+++ b/OpenDose3D.s4ext
@@ -5,8 +5,8 @@
 #
 
 # This is source code manager (i.e. svn)
-scm https
-scmurl https://gitlab.com/opendose/OpenDose3D
+scm git
+scmurl https://gitlab.com/opendose/opendose3d.git
 scmrevision master-stable
 
 # list dependencies


### PR DESCRIPTION
quick fix based on other modules that use https cloning