### PR TITLE
Update SlicerOpenCV.s4ext

### DIFF
--- a/SlicerOpenCV.s4ext
+++ b/SlicerOpenCV.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl git://github.com/Slicer/SlicerOpenCV.git
-scmrevision master
+scmrevision 4.11
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files


### PR DESCRIPTION
Redirect stable (4.11) build to 4.11 branch

Just want a sanity check from anyone.