### PR TITLE
Update PETLiverUptakeMeasurement.s4ext

### DIFF
--- a/PETLiverUptakeMeasurement.s4ext
+++ b/PETLiverUptakeMeasurement.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl https://github.com/QIICR/PETLiverUptakeMeasurement
-scmrevision master
+scmrevision 4.11
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files


### PR DESCRIPTION
The extension's CLI has been updated to interpret ROIs using LPS instead of RAS coordinates following:
https://www.slicer.org/wiki/Documentation/Nightly/Developers/Tutorials/MigrationGuide#Slicer_5.0:_CLI_module_descriptor_XML_files_assume_LPS_coordinate_system_by_default
