### PR TITLE
4.11/SlicerVirtualReality: Update from master to specific version supporting VTK8

### DIFF
--- a/SlicerVirtualReality.s4ext
+++ b/SlicerVirtualReality.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl git://github.com/KitwareMedical/SlicerVirtualReality.git
-scmrevision master
+scmrevision 37a23aebd2e55fc30178b88a7f501e8e31b600ba
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files


### PR DESCRIPTION
Following the integration of PR KitwareMedical/SlicerVirtualReality#84 (See [1]),
the project only support VTK 9.

[1]https://github.com/KitwareMedical/SlicerVirtualReality/pull/84