### PR TITLE
Add SlicerNetstim extension

### DIFF
--- a/SlicerNetstim.s4ext
+++ b/SlicerNetstim.s4ext
@@ -1,0 +1,44 @@
+#
+# First token of each non-comment line is the keyword and the rest of the line
+# (including spaces) is the value.
+# - the value can be blank
+#
+
+# This is source code manager (i.e. svn)
+scm git
+scmurl https://github.com/netstim/SlicerNetstim.git
+scmrevision master
+
+# list dependencies
+# - These should be names of other modules that have .s4ext files
+# - The dependencies will be built first
+depends SlicerRT MarkupsToModel
+
+# Inner build directory (default is ".")
+build_subdirectory .
+
+# homepage
+homepage https://github.com/netstim/SlicerNetstim
+
+# Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
+# For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)
+contributors Simon Oxenford (Charite Berlin)
+
+# Match category in the xml description of the module (where it shows up in Modules menu)
+category Netstim
+
+# url to icon (png, size 128x128 pixels)
+iconurl https://raw.githubusercontent.com/netstim/SlicerNetstim/master/logo.png
+
+# Give people an idea what to expect from this code
+#  - Is it just a test or something you stand behind?
+status beta
+
+# One line stating what the module does
+description Netstim modules collection for deep brain stimulation applications
+
+# Space separated list of urls
+screenshoturls https://raw.githubusercontent.com/netstim/SlicerNetstim/master/Documentation/Screenshot.png
+
+# 0 or 1: Define if the extension should be enabled after its installation.
+enabled 1


### PR DESCRIPTION
As we talked yesterday with @lassoan I include here these set of modules. Below I put some comments that perhaps you have thoughts on.

- [x] Extension has a reasonable name (not too general, not too narrow, suggests what the extension is for)
- [x] Repository name is Slicer+ExtensionName
- [x] Repository is associated with `3d-slicer-extension` GitHub topic so that it is listed [here](https://github.com/topics/3d-slicer-extension). To edit topics, click the settings icon in the right side of "About" section header and enter `3d-slicer-extension` in "Topics" and click "Save changes". To learn more about topics, read https://help.github.com/en/articles/about-topics
- [x] Extension description summarizes in 1-2 sentences what the extension is usable (should be understandable for non-experts)
- [x] Any known related patents must be mentioned in the extension description.
- [x] If source code license is more restrictive for users than BSD, MIT, Apache, or 3D Slicer license then the name of the used license must be mentioned in the extension description.
- [x] Extension URL and revision (scmurl, scmrevision) is correct, consider using a branch name (master, release, ...) instead of a specific git has to avoid re-submitting pull request whenever the extension is updated
- [x] Extension icon URL is correct (do not use the icon's webpage but the raw data download URL that you get from the download button - it should look something like this: https://github.com/user/project/raw/main/path/to/icon.png)
- [x] Screenshot URLs (screenshoturls) are correct, contains at least one
- [x] Homepage URL points to valid webpage containing the following:
  - [x] Extension name
  - [x] Short description: 1-2 sentences, which summarizes what the extension is usable for
  - [x] At least one nice, informative image, that illustrates what the extension can do. It may be a screenshot.
  - [x] Description of contained modules: at one sentence for each module
  - [x] Tutorial: step-by-step description of at least the most typical use case, include a few screenshots, provide download links to sample input data set
  - [x] Publication: link to publication and/or to PubMed reference (if available)
  - [x] License: We suggest you use a permissive license that includes patent and contribution clauses.  This will help protect developers and ensure the code remains freely available.  We suggest you use the [Slicer License](https://github.com/Slicer/Slicer/blob/master/License.txt) or the [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0). Always mention in your README file the license you have chosen.  If you choose a different license, explain why to the extension maintainers. Depending on the license we may not be able to host your work. Read [here](https://opensource.guide/legal/#which-open-source-license-is-appropriate-for-my-project) to learn more about licenses.
  - [x] Content of submitted s4ext file is consistent with the top-level CMakeLists.txt file in the repository (description, URLs, dependencies, etc. are the same)


One thing missing would be including SlicerNetstimLib scripts to the package. Not sure which is the best place to put them. They use logic from different modules in the extension to build scenes.

I commented out the `add_subdirectory(AlphaOmega)` so it's not included in the Slicer build. This can then be patched when I compile for myself.
