### PR TITLE
ENH: Update SlicerCMF extensions scmrevision

### DIFF
--- a/MeshToLabelMap.s4ext
+++ b/MeshToLabelMap.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl git://github.com/NIRALUser/MeshToLabelMap.git
-scmrevision 62186d7221dd7e475b7c4ec31b2b9e246b6cabc1
+scmrevision master
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files

--- a/ModelToModelDistance.s4ext
+++ b/ModelToModelDistance.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl git://github.com/NIRALUser/3DMetricTools.git
-scmrevision 4b4e478f9e20ecef0f66a20eb6719bd4a8c4d949
+scmrevision master
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files

--- a/ShapePopulationViewer.s4ext
+++ b/ShapePopulationViewer.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl git://github.com/NIRALUser/ShapePopulationViewer.git
-scmrevision d0058ba2989b7154fb2f111668429c7cd36081bf
+scmrevision master
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files

--- a/SlicerCMF.s4ext
+++ b/SlicerCMF.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl git://github.com/DCBIA-OrthoLab/SlicerCMF.git
-scmrevision 4047e7afcba5cda8abcd432cafa1f7b6b16fe010
+scmrevision master
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files


### PR DESCRIPTION
SlicerCMF, and some of its dependencies, are pinned to a particular git revision. I've changed these all to use `master`.

- [SlicerCMF](https://github.com/DCBIA-OrthoLab/SlicerCMF)
- [MeshToLabelMap](https://github.com/NIRALUser/MeshToLabelMap)
- [ModelToModelDistance](https://github.com/NIRALUser/3DMetricTools)
- [ShapePopulationViewer](https://github.com/NIRALUser/ShapePopulationViewer)