### PR TITLE
ENH: Remove Auto3dgm as a dependency

### DIFF
--- a/SlicerMorph.s4ext
+++ b/SlicerMorph.s4ext
@@ -12,7 +12,7 @@ scmrevision master
 # list dependencies
 # - These should be names of other modules that have .s4ext files
 # - The dependencies will be built first
-depends     Auto3dgm SegmentEditorExtraEffects Sandbox SlicerIGT RawImageGuess SlicerDcm2nii SurfaceWrapSolidify
+depends     SegmentEditorExtraEffects Sandbox SlicerIGT RawImageGuess SlicerDcm2nii SurfaceWrapSolidify
 
 # Inner build directory (default is .)
 build_subdirectory .


### PR DESCRIPTION
This commit removes Auto3dgm as a dependency of the SlicerMorph extension.