### PR TITLE
ENH: Remove unnecessary dependencies

### DIFF
--- a/SlicerMorph.s4ext
+++ b/SlicerMorph.s4ext
@@ -12,7 +12,7 @@ scmrevision master
 # list dependencies
 # - These should be names of other modules that have .s4ext files
 # - The dependencies will be built first
-depends     SegmentEditorExtraEffects Sandbox SlicerIGT RawImageGuess SlicerDcm2nii SurfaceWrapSolidify
+depends     SegmentEditorExtraEffects
 
 # Inner build directory (default is .)
 build_subdirectory .


### PR DESCRIPTION
Sandbox, SlicerIGT, RawImageGuess, SlicerDcm2nii, and SurfaceWrapSolidify are not true dependencies of the SlicerMorph extension, so it's not necessary to install before use. We plan to replace this default installation with an option in SlicerMorph to install recommended extensions.

