### PR TITLE
DatabaseInteractor updated to use latest code (5.0 branch)

### DIFF
--- a/DatabaseInteractor.s4ext
+++ b/DatabaseInteractor.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl https://github.com/DCBIA-OrthoLab/DatabaseInteractorExtension.git
-scmrevision release
+scmrevision master
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files
@@ -32,7 +32,7 @@ iconurl https://www.slicer.org/w/images/7/7f/DatabaseInteractor_Logo.png
 
 # Give people an idea what to expect from this code
 #  - Is it just a test or something you stand behind?
-status 
+status
 
 # One line stating what the module does
 description This extension can interact with online data in a database and local folders.


### PR DESCRIPTION
Similar to https://github.com/Slicer/ExtensionsIndex/pull/1856 but for the 5.0 branch

Updating DatabaseInteractor to use the latest of its master branch will include the fix for the extension icon and screenshots to show up correctly from the Extensions Manager.

cc: @jcfr @juanprietob