### PR TITLE
Switch to forks to fix icon issues (5.0 branch)

### DIFF
--- a/BrainVolumeRefinement.s4ext
+++ b/BrainVolumeRefinement.s4ext
@@ -6,8 +6,8 @@
 
 # This is source code manager (i.e. svn)
 scm git
-scmurl https://github.com/CSIM-Toolkits/SlicerBrainVolumeRefinement.git
-scmrevision master
+scmurl https://github.com/jamesobutler/SlicerBrainVolumeRefinement.git
+scmrevision main
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files
@@ -32,7 +32,7 @@ iconurl https://www.slicer.org/w/images/2/2c/BVeR-logo.png
 
 # Give people an idea what to expect from this code
 #  - Is it just a test or something you stand behind?
-status 
+status
 
 # One line stating what the module does
 description This extension offers algorithms to performs brain volume refinements due to previous image processing that results on small data artifacts. For instance, the BVeR method is designed to correct small oversegmentation found at brain extraction methods such as FSL-BET, FreeSurfer, AFNI, ROBEX and others.

--- a/ModelClip.s4ext
+++ b/ModelClip.s4ext
@@ -6,8 +6,8 @@
 
 # This is source code manager (i.e. svn)
 scm git
-scmurl https://github.com/Ting-Jia/ModelClip.git
-scmrevision 7de8c132cf13fccedc46830d4bf5c33a91e7bd66
+scmurl https://github.com/jamesobutler/ModelClip.git
+scmrevision main
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files
@@ -32,7 +32,7 @@ iconurl http://www.slicer.org/slicerWiki/index.php/File:ModelClipIcon.png
 
 # Give people an idea what to expect from this code
 #  - Is it just a test or something you stand behind?
-status 
+status
 
 # One line stating what the module does
 description This is an extension module to set the osteotomy trajectory with multiple planes and clip with just one click.


### PR DESCRIPTION
**This is the same as https://github.com/Slicer/ExtensionsIndex/pull/1861, but for the 5.0 branch.**

re https://github.com/Slicer/Slicer/issues/4936#issuecomment-1175748890

This switches SlicerRegularizedFastMarching, ModelClip and SlicerBrainVolumeRefinement to my forked versions to fix invalid icon and screenshot links from the Extensions Manager.