### PR TITLE
BUG: Use HTTPS SlicerMarkupConstraints homepage

### DIFF
--- a/SlicerMarkupConstraints.s4ext
+++ b/SlicerMarkupConstraints.s4ext
@@ -18,7 +18,7 @@ depends NA
 build_subdirectory .
 
 # homepage
-homepage http://github.com/KitwareMedical/SlicerMarkupConstraints
+homepage https://github.com/KitwareMedical/SlicerMarkupConstraints
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
 # For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)


### PR DESCRIPTION
Markup Constraints homepage should use HTTPS. The change is reflected in the CMakeLists here:

https://github.com/KitwareMedical/SlicerMarkupConstraints/commit/479117917e29a8e99299740fb558996928070dbf