### PR TITLE
CI: Use next-gen Docker convenience images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   check-filenames:
     docker:
-      - image: circleci/python:3.7.0-stretch
+      - image: cimg/python:3.10
     steps:
       - checkout
       - run:
@@ -13,7 +13,7 @@ jobs:
 
   check-description-files:
     docker:
-      - image: circleci/python:3.7.0-stretch
+      - image: cimg/python:3.10
     steps:
       - checkout
       - run:
@@ -23,7 +23,7 @@ jobs:
 
   check-new-description-files:
     docker:
-      - image: circleci/python:3.7.0-stretch
+      - image: cimg/python:3.10
     steps:
       - checkout
       - run:


### PR DESCRIPTION
See https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034.

> The legacy CircleCI convenience images are Debian Jessie - or Stretch -based images, however the next-gen images, cimg, extend the official Ubuntu image.
[[source](https://circleci.com/docs/circleci-images#pre-installed-tools)]