### PR TITLE
Add Markup Constraints for Slicer 5.0

### DIFF
--- a/SlicerMarkupConstraints.s4ext
+++ b/SlicerMarkupConstraints.s4ext
@@ -1,0 +1,44 @@
+#
+# First token of each non-comment line is the keyword and the rest of the line
+# (including spaces) is the value.
+# - the value can be blank
+#
+
+# This is source code manager
+scm git
+scmurl https://github.com/KitwareMedical/SlicerMarkupConstraints.git
+scmrevision 5.0
+
+# list dependencies
+# - These should be names of other modules that have .s4ext files
+# - The dependencies will be built first
+depends NA
+
+# Inner build directory (default is ".")
+build_subdirectory .
+
+# homepage
+homepage https://github.com/KitwareMedical/SlicerMarkupConstraints/tree/5.0
+
+# Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
+# For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)
+contributors David Allemang (Kitware)
+
+# Match category in the xml description of the module (where it shows up in Modules menu)
+category Developer Tools
+
+# url to icon (png, size 128x128 pixels)
+iconurl https://raw.githubusercontent.com/KitwareMedical/SlicerMarkupConstraints/5.0/SlicerMarkupConstraints.png
+
+# Give people an idea what to expect from this code
+#  - Is it just a test or something you stand behind?
+status beta
+
+# One line stating what the module does
+description This module is a development tool which allows extension developers to constrain the placement of markup control points based on other vtk objects. The extension was created during Slicer Project Week 37 for the Q3DCExtension project.
+
+# Space separated list of urls
+screenshoturls https://raw.githubusercontent.com/KitwareMedical/SlicerMarkupConstraints/5.0/Docs/static-project-angle.png
+
+# 0 or 1: Define if the extension should be enabled after its installation.
+enabled 1


### PR DESCRIPTION
Adds SlicerMarkupConstraints to Slicer 5.0 branch. The content of the `.s4ext` is the same, but points to the `5.0` branch in https://github.com/KitwareMedical/SlicerMarkupConstraints

See https://github.com/Slicer/ExtensionsIndex/pull/1878 and https://github.com/Slicer/ExtensionsIndex/pull/1882

I've signed this commit in hopes that the CI tests run automatically... we will see if that works.