### PR TITLE
Switch SlicerRT to use 5.0 branch

### DIFF
--- a/SlicerRT.s4ext
+++ b/SlicerRT.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl https://github.com/SlicerRt/SlicerRT.git
-scmrevision master
+scmrevision 5.0
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files


### PR DESCRIPTION
Recent change in Slicer required updates in SlicerRT that are not compatible with the stable version.