### PR TITLE
ENH changed homepage link from github to dedicated page

### DIFF
--- a/AstmPhantomTest.s4ext
+++ b/AstmPhantomTest.s4ext
@@ -18,7 +18,7 @@ depends     SlicerOpenIGTLink
 build_subdirectory .
 
 # homepage
-homepage    https://github.com/Atracsys/SlicerAstmPhantomTest
+homepage    https://www.atracsys-measurement.com/astm/
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
 # For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)


### PR DESCRIPTION
I just updated the homepage link to a dedicated webpage instead of the github.