### PR TITLE
ENH: Update Q3DC 5.0 branch

### DIFF
--- a/Q3DC.s4ext
+++ b/Q3DC.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl https://github.com/DCBIA-OrthoLab/Q3DCExtension.git
-scmrevision master
+scmrevision 5.0
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files


### PR DESCRIPTION
I created a 5.0 branch in DCBIA-OrthoLab/Q3DCExtension; this commit updates Q3DC.s4ext to refer to it in the 5.0 branch here.