### PR TITLE
ENH: Update Q3DC depends

### DIFF
--- a/Q3DC.s4ext
+++ b/Q3DC.s4ext
@@ -4,7 +4,7 @@
 # - the value can be blank
 #
 
-# This is source code manager (i.e. svn)
+# This is source code manager
 scm git
 scmurl https://github.com/DCBIA-OrthoLab/Q3DCExtension.git
 scmrevision master
@@ -12,7 +12,7 @@ scmrevision master
 # list dependencies
 # - These should be names of other modules that have .s4ext files
 # - The dependencies will be built first
-depends NA
+depends SlicerMarkupConstraints
 
 # Inner build directory (default is ".")
 build_subdirectory .
@@ -22,7 +22,7 @@ homepage http://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extens
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
 # For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)
-contributors Lucie Macron (University of Michigan),  Jean-Baptiste Vimort (University of Michigan)
+contributors Lucie Macron (University of Michigan),  Jean-Baptiste Vimort (University of Michigan), James Hoctor (Kitware Inc), David Allemang (Kitware Inc)
 
 # Match category in the xml description of the module (where it shows up in Modules menu)
 category Shape Analysis


### PR DESCRIPTION
Q3DC now depends on SlicerMarkupConstraints; add this to the Q3DC.s4ext

Also update the contributors and comments to match the build tree s4ext.

