### PR TITLE
5.2: Update SlicerMorph to a fixed version

### DIFF
--- a/SlicerMorph.s4ext
+++ b/SlicerMorph.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl https://github.com/SlicerMorph/SlicerMorph.git
-scmrevision master  
+scmrevision 6458880d9998cd969dd2205929e901ae6e605399  
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files


### PR DESCRIPTION
This commit updates to a fixed version to ensure build associated with the current stable works as we are updating SlicerMorph to relies on features available only in the preview build of Slicer.