### PR TITLE
Fix SlicerMEMOS repo branch name

### DIFF
--- a/MEMOS.s4ext
+++ b/MEMOS.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl https://github.com/SlicerMorph/SlicerMEMOS
-scmrevision master
+scmrevision main
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files


### PR DESCRIPTION
This commit updates the MEMOS extension to fix the SlicerMEMOS repository branch name.