### PR TITLE
Add SlicerNeuro extension

### DIFF
--- a/SlicerNeuro.s4ext
+++ b/SlicerNeuro.s4ext
@@ -1,0 +1,44 @@
+#
+# First token of each non-comment line is the keyword and the rest of the line
+# (including spaces) is the value.
+# - the value can be blank
+#
+
+# This is source code manager
+scm git
+scmurl https://github.com/Slicer/SlicerNeuro
+scmrevision main
+
+# list dependencies
+# - These should be names of other modules that have .s4ext files
+# - The dependencies will be built first
+depends UKFTractography SwissSkullStripper SlicerFreeSurfer SlicerDcm2nii SlicerDMRI HDBrainExtraction
+
+# Inner build directory (default is ".")
+build_subdirectory .
+
+# homepage
+homepage https://github.com/Slicer/SlicerNeuro
+
+# Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
+# For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)
+contributors Andras Lasso (PerkLab (Queen's University))
+
+# Match category in the xml description of the module (where it shows up in Modules menu)
+category Neuroimaging
+
+# url to icon (png, size 128x128 pixels)
+iconurl https://raw.githubusercontent.com/Slicer/SlicerNeuro/main/SlicerNeuro.png
+
+# Give people an idea what to expect from this code
+#  - Is it just a test or something you stand behind?
+status
+
+# One line stating what the module does
+description This extension provides ACPC coordinate transformation tool and installs extensions commonly needed for neuroimaging.
+
+# Space separated list of urls
+screenshoturls https://raw.githubusercontent.com/Slicer/SlicerNeuro/main/Docs/module_acpctransform_1.png
+
+# 0 or 1: Define if the extension should be enabled after its installation.
+enabled 1

--- a/SlicerNeuro.s4ext
+++ b/SlicerNeuro.s4ext
@@ -12,7 +12,7 @@ scmrevision main
 # list dependencies
 # - These should be names of other modules that have .s4ext files
 # - The dependencies will be built first
-depends UKFTractography SwissSkullStripper SlicerFreeSurfer SlicerDcm2nii SlicerDMRI HDBrainExtraction
+depends UKFTractography SwissSkullStripper SlicerFreeSurfer SlicerDcm2nii SlicerDMRI HDBrainExtraction SlicerWMA
 
 # Inner build directory (default is ".")
 build_subdirectory .


### PR DESCRIPTION
While translating Slicer to different languagues we noticed that a very specialized brain coordinate system transformation module (ACPCTransform) is still in Slicer core. This is an outlier, because all other domain-specific modules are now in extensions. To make translation and maintenance of Slicer core easier it makes sense to move ACPCTransform to an extension.

Since there was no existing extension for generic neuroimaging modules, a new SlicerNeuro extension has been added.

Since the extension only contains one module, it would not be that useful, so some other neuroimaging related extensions are added as dependencies, so the extension can serve as a starting point for users in this field (they need to install only one extension to get all). If more modules will be added to the extension then this may be revisited (extensions that are not actually required can be removed from the extension dependency list).

# New extension

- [x] Extension has a reasonable name (not too general, not too narrow, suggests what the extension is for)
- [x] Repository name is Slicer+ExtensionName
- [x] Repository is associated with `3d-slicer-extension` GitHub topic so that it is listed [here](https://github.com/topics/3d-slicer-extension). To edit topics, click the settings icon in the right side of "About" section header and enter `3d-slicer-extension` in "Topics" and click "Save changes". To learn more about topics, read https://help.github.com/en/articles/about-topics
- [x] Extension description summarizes in 1-2 sentences what the extension is usable (should be understandable for non-experts)
- [x] Any known related patents must be mentioned in the extension description.
- [x] LICENSE.txt is present in the repository root. MIT  (https://choosealicense.com/licenses/mit/) or Apache (https://choosealicense.com/licenses/apache-2.0/) license is recommended. If source code license is more restrictive for users than MIT, BSD, Apache, or 3D Slicer license then the name of the used license must be mentioned in the extension description.
- [x] Extension URL and revision (scmurl, scmrevision) is correct, consider using a branch name (main, release, ...) instead of a specific git has to avoid re-submitting pull request whenever the extension is updated
- [x] Extension icon URL is correct (do not use the icon's webpage but the raw data download URL that you get from the download button - it should look something like this: https://raw.githubusercontent.com/user/repo/main/SomeIcon.png)
- [x] Screenshot URLs (screenshoturls) are correct, contains at least one
- [x] Homepage URL points to valid webpage containing the following:
  - [x] Extension name
  - [x] Short description: 1-2 sentences, which summarizes what the extension is usable for
  - [x] At least one nice, informative image, that illustrates what the extension can do. It may be a screenshot.
  - [x] Description of contained modules: at one sentence for each module
  - [x] Tutorial: step-by-step description of at least the most typical use case, include a few screenshots, provide download links to sample input data set
  - [x] Publication: link to publication and/or to PubMed reference (if available)
  - [x] License: We suggest you use a permissive license that includes patent and contribution clauses.  This will help protect developers and ensure the code remains freely available.  We suggest you use the [Slicer License](https://github.com/Slicer/Slicer/blob/main/License.txt) or the [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0). Always mention in your README file the license you have chosen.  If you choose a different license, explain why to the extension maintainers. Depending on the license we may not be able to host your work. Read [here](https://opensource.guide/legal/#which-open-source-license-is-appropriate-for-my-project) to learn more about licenses.
  - [x] Content of submitted s4ext file is consistent with the top-level CMakeLists.txt file in the repository (description, URLs, dependencies, etc. are the same)
