### PR TITLE
ENH: Update SlicerPyTorch to use main branch

### DIFF
--- a/PyTorch.s4ext
+++ b/PyTorch.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager
 scm git
 scmurl https://github.com/fepegar/SlicerPyTorch.git
-scmrevision master
+scmrevision main
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files


### PR DESCRIPTION
This updates SlicerPyTorch to build using the `main` branch. This repo appears to have recently updated from `master` to `main` resulting in 

https://slicer.cdash.org/build/2998898/configure
```
CMake Error at CMakeLists.txt:3 (message):
  Failed to download extension using
  GIT_REPOSITORY;https://github.com/fepegar/SlicerPyTorch.git;GIT_TAG;master

  Cloning into 'PyTorch'...

  fatal: invalid reference: master

  CMake Error at
  PyTorch-download-prefix/tmp/PyTorch-download-gitclone.cmake:40 (message):

    Failed to checkout tag: 'master'
```