### PR TITLE
ENH: Update TorchIO to use main branch (5.2 branch target)

### DIFF
--- a/TorchIO.s4ext
+++ b/TorchIO.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl https://github.com/fepegar/SlicerTorchIO.git
-scmrevision master
+scmrevision main
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files


### PR DESCRIPTION
This updates TorchIO to build using the `main` branch. This repo appears to have recently updated from `master` to `main` resulting in 

https://slicer.cdash.org/build/3003359/configure
```
CMake Error at CMakeLists.txt:3 (message):
-- Configuring incomplete, errors occurred!
  Failed to download extension using
  GIT_REPOSITORY;https://github.com/fepegar/SlicerTorchIO.git;GIT_TAG;master

  Cloning into 'TorchIO'...

  fatal: invalid reference: master

  CMake Error at
  TorchIO-download-prefix/tmp/TorchIO-download-gitclone.cmake:40 (message):

    Failed to checkout tag: 'master'
```