### PR TITLE
Update dependencies for AutoscoperM

### DIFF
--- a/SlicerAutoscoperM.s4ext
+++ b/SlicerAutoscoperM.s4ext
@@ -12,7 +12,7 @@ scmrevision main
 # list dependencies
 # - These should be names of other modules that have .s4ext files
 # - The dependencies will be built first
-depends NA
+depends Sandbox SegmentEditorExtraEffects
 
 # Inner build directory (default is ".")
 build_subdirectory inner-build


### PR DESCRIPTION
An upcoming update, [see PR #12](https://github.com/BrownBiomechanics/SlicerAutoscoperM/pull/12), to Autoscoper will require the following extensions:
* [SlicerSandbox](https://github.com/PerkLab/SlicerSandbox)
* [SlicerSegmentEditorExtraEffects](https://github.com/lassoan/SlicerSegmentEditorExtraEffects)

Related:
* https://github.com/BrownBiomechanics/SlicerAutoscoperM/pull/12