### PR TITLE
BUG: Add the `UKFTractography` dependency to the `SlicerDMRI` extension

### DIFF
--- a/SlicerDMRI.s4ext
+++ b/SlicerDMRI.s4ext
@@ -2,7 +2,7 @@ scm git
 scmurl https://github.com/SlicerDMRI/SlicerDMRI.git
 scmrevision master
 
-depends NA
+depends UKFTractography
 
 build_subdirectory inner-build
 


### PR DESCRIPTION
Add the `UKFTractography` dependency to the `SlicerDMRI` extension, following the dependenciest listed in the latter's top-level `CMakeLists.txt` file:
https://github.com/SlicerDMRI/SlicerDMRI/blob/610533480896d2884cb9ab0671c88874d237247d/CMakeLists.txt#L14