### PR TITLE
BUG: Update mpReview.s4ext

### DIFF
--- a/mpReview.s4ext
+++ b/mpReview.s4ext
@@ -12,7 +12,7 @@ scmrevision master
 # list dependencies
 # - These should be names of other modules that have .s4ext files
 # - The dependencies will be built first
-depends     SlicerDevelopmentToolbox
+depends     SlicerDevelopmentToolbox QuantitativeReporting DICOMwebBrowser
 
 # Inner build directory (default is ".")
 build_subdirectory .


### PR DESCRIPTION
Added QuantitativeReporting and DICOMwebBrowser as dependencies to mpReview

<!--
Thank you for contributing to 3D Slicer!
- To add a new extension with this pull request: Please keep content of "New extension" section and put an 'x' in the brackets for each todo item to indicate that you have accomplished that prerequisite.
- To update an existing extension with this pull request: Please delete all text in this template and just describe which extension is updated and optionally tell us in a sentence what has been changed. To make extension updates easier in the future you may consider replacing specific git hash in your s4ext file by a branch name (for example: `main` for Slicer Preview Releases; `(majorVersion).(minorVersion)` such as `4.10` for Slicer Stable Releases).
-->

