### PR TITLE
Update IDCBrowser dependencies

### DIFF
--- a/IDCBrowser.s4ext
+++ b/IDCBrowser.s4ext
@@ -6,7 +6,7 @@ scmrevision main
 # list dependencies
 # - These should be names of other modules that have .s4ext files
 # - The dependencies will be built first
-depends     NA
+depends     QuantitativeReporting
 
 # Inner build directory (default is ".")
 build_subdirectory .


### PR DESCRIPTION
Added QuantitativeReporting as dependency, since in practice it is needed to make sense of a lot of interesting content in IDC.