### PR TITLE
Add dependency for AutomatedDentalTools

### DIFF
--- a/AutomatedDentalTools.s4ext
+++ b/AutomatedDentalTools.s4ext
@@ -13,7 +13,7 @@ scmrevision main
 # list dependencies
 # - These should be names of other modules that have .s4ext files
 # - The dependencies will be built first
-depends NA
+depends SlicerDentalModelSeg
 
 # Inner build directory (default is ".")
 build_subdirectory .


### PR DESCRIPTION
SlicerAutomatedDentalTools requires SlicerDentalModelSeg but it was not added to the extension index entry.

See https://github.com/DCBIA-OrthoLab/SlicerAutomatedDentalTools/blob/main/CMakeLists.txt#L13

cc @GaelleLeroux