### PR TITLE
Revert "ExtraMarkups: Relocate repository to gitlab. (#1974)"

### DIFF
--- a/ExtraMarkups.s4ext
+++ b/ExtraMarkups.s4ext
@@ -6,7 +6,7 @@
 
 # This is source code manager
 scm git
-scmurl https://gitlab.com/chir-set/SlicerExtraMarkups.git
+scmurl https://github.com/chir-set/SlicerExtraMarkups.git
 scmrevision main
 
 # list dependencies
@@ -18,7 +18,7 @@ depends NA
 build_subdirectory .
 
 # homepage
-homepage https://gitlab.com/chir-set/SlicerExtraMarkups/
+homepage https://github.com/chir-set/SlicerExtraMarkups/
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
 # For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)
@@ -28,7 +28,7 @@ contributors Saleem Edah-Tally ([Surgeon] [Hobbyist developer])
 category Utilities
 
 # url to icon (png, size 128x128 pixels)
-iconurl https://gitlab.com/chir-set/SlicerExtraMarkups/-/raw/main/ExtraMarkups.png
+iconurl https://github.com/chir-set/SlicerExtraMarkups/raw/main/ExtraMarkups.png
 
 # Give people an idea what to expect from this code
 #  - Is it just a test or something you stand behind?
@@ -38,7 +38,7 @@ status
 description This extension adds a <i>Label</i> markups node that draws an arrow with a text label, and a <i>Shape</i> markups node that can draw defined primitive shapes (circle, cone...). The result is controlled by placing usual control points in slice views and 3D views. Each object can be saved in scene and reloaded.
 
 # Space separated list of urls
-screenshoturls https://gitlab.com/chir-set/SlicerExtraMarkups/-/raw/main/Label/Label_0.png https://gitlab.com/chir-set/SlicerExtraMarkups/-/raw/main/Shape/Cone_0.png https://gitlab.com/chir-set/SlicerExtraMarkups/-/raw/main/Shape/Cylinder_0.png https://gitlab.com/chir-set/SlicerExtraMarkups/-/raw/main/Shape/Disk_0.png https://gitlab.com/chir-set/SlicerExtraMarkups/-/raw/main/Shape/Ring_0.png https://gitlab.com/chir-set/SlicerExtraMarkups/-/raw/main/Shape/Sphere_0.png https://gitlab.com/chir-set/SlicerExtraMarkups/-/raw/main/Shape/Tube_0.png https://gitlab.com/chir-set/SlicerExtraMarkups/-/raw/main/Shape/Arc_0.png
+screenshoturls https://github.com/chir-set/SlicerExtraMarkups/raw/main/Label/Label_0.png https://github.com/chir-set/SlicerExtraMarkups/raw/main/Shape/Cone_0.png https://github.com/chir-set/SlicerExtraMarkups/raw/main/Shape/Cylinder_0.png https://github.com/chir-set/SlicerExtraMarkups/raw/main/Shape/Disk_0.png https://github.com/chir-set/SlicerExtraMarkups/raw/main/Shape/Ring_0.png https://github.com/chir-set/SlicerExtraMarkups/raw/main/Shape/Sphere_0.png https://github.com/chir-set/SlicerExtraMarkups/raw/main/Shape/Tube_0.png
 
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 1


### PR DESCRIPTION
This reverts commit 80d7b61012c8c41e33973dafa07d0f4438967643 integrated through https://github.com/Slicer/ExtensionsIndex/pull/1974
