### PR TITLE
STYLE: Fix end-of-file lint check 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# Set update schedule for GitHub Actions
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"
+    commit-message:
+      # Prefix all commit messages with "CI: "
+      prefix: "CI"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,8 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+    - uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
       with:
         python-version: '3.9'
-    - uses: pre-commit/action@v3.0.0
+    - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,4 +18,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
+      with:
+        python-version: '3.9'
     - uses: pre-commit/action@v3.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: "v4.4.0"
+  rev: v4.5.0
   hooks:
   - id: check-added-large-files
     args: ['--maxkb=1024']
@@ -12,7 +12,7 @@ repos:
   - id: trailing-whitespace
 
 - repo: https://github.com/Lucas-C/pre-commit-hooks
-  rev: "v1.5.4"
+  rev: v1.5.5
   hooks:
     - id: forbid-tabs
     - id: remove-tabs

--- a/UHFMRTools.s4ext
+++ b/UHFMRTools.s4ext
@@ -41,4 +41,3 @@ screenshoturls https://github.com/harellab/SlicerUHFMRTools/blob/trunk/doc/Addit
 
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 1
-


### PR DESCRIPTION
This was introduced by https://github.com/Slicer/ExtensionsIndex/commit/0b048645102c573ebbd78228a44a1dc19c2a4098.

This was auto-fixed by running:
`python -m pre_commit run --all-files`