### PR TITLE
CI: Update pre-commit settings to validate github-workflows and dependabot files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,3 +24,9 @@ repos:
     hooks:
       - id: forbid-tabs
       - id: remove-tabs
+
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: "0.28.0"
+    hooks:
+      - id: check-dependabot
+      - id: check-github-workflows


### PR DESCRIPTION
This commit enables the "check-github-workflows" and "check-dependabot" See https://check-jsonschema.readthedocs.io/en/stable/precommit_usage.html

Changes done anticipating the integration of:
* https://github.com/Slicer/ExtensionsIndex/pull/2011