### PR TITLE
BUG: Fix homepage link in AutomatedDentalTools

### DIFF
--- a/AutomatedDentalTools.s4ext
+++ b/AutomatedDentalTools.s4ext
@@ -18,8 +18,7 @@ depends SlicerDentalModelSeg SlicerConda
 # Inner build directory (default is ".")
 build_subdirectory .
 
-# homepage
-https://github.com/DCBIA-OrthoLab/SlicerAutomatedDentalTools/blob/main/README.md
+homepage https://github.com/DCBIA-OrthoLab/SlicerAutomatedDentalTools#readme
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
 # For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)


### PR DESCRIPTION
Metadata key and value are expected to be specified on the same line.

------------------

This issue was identified while working on integrating the following pull requests:
* https://github.com/Slicer/Slicer/pull/7629
* https://github.com/Slicer/ExtensionsIndex/pull/2011