### PR TITLE
Update check_description_files script and fix s4ext files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs:
             # Run checks
             if [[ $added != "" ]]; then
               pip install joblib retry
-              python ./scripts/check_description_files.py --check-git-repository-name $added
+              python ./scripts/check_description_files.py $added
             fi
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
       - run:
           name: Check description files
           command: |
-            python ./scripts/check_description_files.py --check-dependencies . $(find . -name "*.s4ext")
+            python ./scripts/check_description_files.py --check-dependencies . $(find . -maxdepth 1 -name "*.s4ext")
 
   check-new-description-files:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs:
             # Run checks
             if [[ $added != "" ]]; then
               pip install joblib retry
-              python ./scripts/check_description_files.py $added
+              python ./scripts/check_description_files.py --check-urls-reachable $added
             fi
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,46 +19,7 @@ jobs:
           name: Check description files
           command: |
             pip install joblib retry
-            python ./scripts/check_description_files.py --check-dependencies . $(find . -maxdepth 1 -name "*.s4ext")
-
-  check-new-description-files:
-    docker:
-      - image: cimg/python:3.10
-    steps:
-      - checkout
-      - run:
-          name: Lookup base branch (Workaround the lack of CIRCLE_BASE_BRANCH env. variable)
-          # See https://discuss.circleci.com/t/how-to-get-the-pull-request-upstream-branch/5496/2
-          command: |
-            if [[ $CIRCLE_PULL_REQUEST != "" ]]; then
-              for base_branch in origin/main $(git branch -r | grep -E "origin\/[0-9](\.[0-9])+" | sort -r); do
-                differences=$(git diff $base_branch --name-only)
-                if [[ $differences != "" ]]; then
-                  break
-                fi
-              done
-            else
-              base_branch=$CIRCLE_BRANCH
-            fi
-            echo "export BASE_BRANCH=\"$base_branch\"" >> $BASH_ENV
-      - run:
-          name: Check new description files
-          command: |
-            # ignore grep exit code if no description files were added
-            set +e
-
-            echo "BASE_BRANCH is [$BASE_BRANCH]"
-            echo "CIRCLE_BRANCH is [$CIRCLE_BRANCH]"
-
-            # Collect list of new *.s4ext files
-            added=$(git diff $BASE_BRANCH --diff-filter=A --name-only | grep -E "^[^\/]+\.s4ext$")
-            echo "added [$added]"
-
-            # Run checks
-            if [[ $added != "" ]]; then
-              pip install joblib retry
-              python ./scripts/check_description_files.py --check-urls-reachable $added
-            fi
+            python ./scripts/check_description_files.py --check-urls-reachable --check-dependencies . $(find . -maxdepth 1 -name "*.s4ext")
 
 workflows:
   version: 2
@@ -66,4 +27,3 @@ workflows:
     jobs:
       - check-filenames
       - check-description-files
-      - check-new-description-files

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,7 @@ jobs:
       - run:
           name: Check description files
           command: |
+            pip install joblib retry
             python ./scripts/check_description_files.py --check-dependencies . $(find . -maxdepth 1 -name "*.s4ext")
 
   check-new-description-files:
@@ -55,6 +56,7 @@ jobs:
 
             # Run checks
             if [[ $added != "" ]]; then
+              pip install joblib retry
               python ./scripts/check_description_files.py --check-git-repository-name $added
             fi
 

--- a/AnglePlanesExtension.s4ext
+++ b/AnglePlanesExtension.s4ext
@@ -18,7 +18,7 @@ depends NA
 build_subdirectory .
 
 # homepage
-homepage http://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/AnglePlanes
+homepage https://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/AnglePlanes
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
 # For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)

--- a/AnglePlanesExtension.s4ext
+++ b/AnglePlanesExtension.s4ext
@@ -38,7 +38,7 @@ status
 description This Module is used to calculate the angle between two planes by using the normals. The user gets the choice to use two planes which are already implemented on Slicer or they can define a plane by using landmarks (at least 3 landmarks). Plane can also be saved to be reused for other models.
 
 # Space separated list of urls
-screenshoturls http://www.slicer.org/slicerWiki/images/b/ba/Interface_AnglePlanes.png
+screenshoturls https://www.slicer.org/slicerWiki/images/b/ba/Interface_AnglePlanes.png
 
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 1

--- a/AnomalousFiltersExtension.s4ext
+++ b/AnomalousFiltersExtension.s4ext
@@ -18,7 +18,7 @@ depends NA
 build_subdirectory .
 
 # homepage
-homepage http://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/AnomalousFilters
+homepage https://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/AnomalousFilters
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
 # For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)

--- a/AnomalousFiltersExtension.s4ext
+++ b/AnomalousFiltersExtension.s4ext
@@ -38,7 +38,7 @@ status
 description This extension aims to provide several approaches in order to apply the anomalous spatial filters on medical images. The methods provided here are numerical solution of the generalized anomalous diffusion proposed by Constantino Tsallis, which, in other words, provide a numerical solution to the porous media equation (Fokker-Planck anomalous heat equation). At the moment, the Modules available are suppose to be used on MRI volumes namely T1, T2, T2-FLAIR and PD weighted images, and diffusion weighted images (DWI and DTI). Future developments will add new functionalities in order to attenuate image noise in other imaging modalities. More details could be found in the wiki page.
 
 # Space separated list of urls
-screenshoturls https://www.slicer.org/slicerWiki/images/6/64/MRI_raw.png https://www.slicer.org/slicerWiki/images/e/e8/MRI_AAD.png https://www.slicer.org/slicerWiki/images/0/0d/MRI_IAD.png https://www.slicer.org/w/images/4/40/DTI_FA_raw.png https://www.slicer.org/w/images/7/7c/DTI_FA_AAD.png https://www.slicer.org/w/images/a/a0/Tractography_AAD.png
+screenshoturls https://www.slicer.org/slicerWiki/images/6/64/MRI_raw.png https://www.slicer.org/slicerWiki/images/e/e8/MRI_AAD.png https://www.slicer.org/slicerWiki/images/0/0d/MRI_IAD.png https://www.slicer.org/slicerWiki/images/4/40/DTI_FA_raw.png https://www.slicer.org/slicerWiki/images/7/7c/DTI_FA_AAD.png https://www.slicer.org/slicerWiki/images/a/a0/Tractography_AAD.png
 
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 1

--- a/AutomatedDentalTools.s4ext
+++ b/AutomatedDentalTools.s4ext
@@ -22,7 +22,7 @@ homepage https://github.com/DCBIA-OrthoLab/SlicerAutomatedDentalTools#readme
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
 # For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)
-Authors: Maxime Gillot (University of Michigan), Baptiste Baquero (UoM), Juan Carlos Prieto (University of North Carolina)
+contributors Maxime Gillot (University of Michigan), Baptiste Baquero (UoM), Juan Carlos Prieto (University of North Carolina)
 
 # Match category in the xml description of the module (where it shows up in Modules menu)
 category Segmentation

--- a/BrainVolumeRefinement.s4ext
+++ b/BrainVolumeRefinement.s4ext
@@ -28,7 +28,7 @@ contributors Antonio Carlos da S. Senra Filho, Fabricio H. Simozo, Luiz Otavio M
 category Segmentation
 
 # url to icon (png, size 128x128 pixels)
-iconurl https://www.slicer.org/w/images/2/2c/BVeR-logo.png
+iconurl https://www.slicer.org/slicerWiki/images/2/2c/BVeR-logo.png
 
 # Give people an idea what to expect from this code
 #  - Is it just a test or something you stand behind?
@@ -38,7 +38,7 @@ status
 description This extension offers algorithms to performs brain volume refinements due to previous image processing that results on small data artifacts. For instance, the BVeR method is designed to correct small oversegmentation found at brain extraction methods such as FSL-BET, FreeSurfer, AFNI, ROBEX and others.
 
 # Space separated list of urls
-screenshoturls https://www.slicer.org/w/images/4/47/T1-FS.png https://www.slicer.org/w/images/f/f4/T1-FS-BVeR.png https://www.slicer.org/w/images/2/2f/BVeR-3D-Anterior.png https://www.slicer.org/w/images/2/29/BVeR-3D-Lateral.png https://www.slicer.org/w/images/e/ee/BVeR-3D-FreeView.png
+screenshoturls https://www.slicer.org/slicerWiki/images/4/47/T1-FS.png https://www.slicer.org/slicerWiki/images/f/f4/T1-FS-BVeR.png https://www.slicer.org/slicerWiki/images/2/2f/BVeR-3D-Anterior.png https://www.slicer.org/slicerWiki/images/2/29/BVeR-3D-Lateral.png https://www.slicer.org/slicerWiki/images/e/ee/BVeR-3D-FreeView.png
 
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 1

--- a/CMFreg.s4ext
+++ b/CMFreg.s4ext
@@ -38,7 +38,7 @@ status
 description Tools package for the cranio-maxillofacial registration
 
 # Space separated list of urls
-screenshoturls http://www.slicer.org/slicerWiki/images/1/15/BaselineFollowupSCANCMFreg.png http://www.slicer.org/slicerWiki/images/0/0b/GrowingInterface.png http://www.slicer.org/slicerWiki/images/4/4a/InputSegToExtractionCMFreg.png http://www.slicer.org/slicerWiki/images/4/46/BaselineSegmentationMaskCMFreg.png
+screenshoturls https://www.slicer.org/slicerWiki/images/1/15/BaselineFollowupSCANCMFreg.png https://www.slicer.org/slicerWiki/images/0/0b/GrowingInterface.png https://www.slicer.org/slicerWiki/images/4/4a/InputSegToExtractionCMFreg.png https://www.slicer.org/slicerWiki/images/4/46/BaselineSegmentationMaskCMFreg.png
 
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 1

--- a/CMFreg.s4ext
+++ b/CMFreg.s4ext
@@ -18,7 +18,7 @@ depends NA
 build_subdirectory .
 
 # homepage
-homepage http://www.slicer.org/slicerWiki/index.php/Documentation/4.4/Extensions/CMFreg
+homepage https://www.slicer.org/slicerWiki/index.php/Documentation/4.4/Extensions/CMFreg
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
 # For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)

--- a/CMFreg.s4ext
+++ b/CMFreg.s4ext
@@ -28,7 +28,7 @@ contributors Vinicius Boen (Univ of Michigan), Manson Winsauer (UNC), Jean-Bapti
 category Registration
 
 # url to icon (png, size 128x128 pixels)
-iconurl http://www.slicer.org/slicerWiki/images/b/bc/BaselineFollowupSCANRegisteredCMFreg2.png
+iconurl https://www.slicer.org/slicerWiki/images/b/bc/BaselineFollowupSCANRegisteredCMFreg2.png
 
 # Give people an idea what to expect from this code
 #  - Is it just a test or something you stand behind?

--- a/CarreraSlice.s4ext
+++ b/CarreraSlice.s4ext
@@ -38,7 +38,7 @@ status Beta
 description This extension provides an interactive 3D segmentation tool.
 
 # Space separated list of urls
-screenshoturls http://www.slicer.org/slicerWiki/images/thumb/2/2c/DrawLabel.png/500px-DrawLabel.png  http://www.na-mic.org/Wiki/images/thumb/d/d0/TendonSegment.png/800px-TendonSegment.png  http://www.na-mic.org/Wiki/images/thumb/b/b8/FiducialSnapshotX.png/800px-FiducialSnapshotX.png
+screenshoturls http://www.slicer.org/slicerWiki/images/thumb/2/2c/DrawLabel.png/500px-DrawLabel.png http://www.na-mic.org/Wiki/images/thumb/d/d0/TendonSegment.png/800px-TendonSegment.png http://www.na-mic.org/Wiki/images/thumb/b/b8/FiducialSnapshotX.png/800px-FiducialSnapshotX.png
 
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 1

--- a/CarreraSlice.s4ext
+++ b/CarreraSlice.s4ext
@@ -38,7 +38,7 @@ status Beta
 description This extension provides an interactive 3D segmentation tool.
 
 # Space separated list of urls
-screenshoturls https://www.slicer.org/slicerWiki/images/thumb/2/2c/DrawLabel.png/500px-DrawLabel.png https://www.na-mic.org/Wiki/images/thumb/d/d0/TendonSegment.png/800px-TendonSegment.png https://www.na-mic.org/Wiki/images/thumb/b/b8/FiducialSnapshotX.png/800px-FiducialSnapshotX.png
+screenshoturls https://www.slicer.org/slicerWiki/images/thumb/2/2c/DrawLabel.png/500px-DrawLabel.png https://www.na-mic.org/w/img_auth.php/d/d0/TendonSegment.png https://www.na-mic.org/w/img_auth.php/b/b8/FiducialSnapshotX.png
 
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 1

--- a/CarreraSlice.s4ext
+++ b/CarreraSlice.s4ext
@@ -38,7 +38,7 @@ status Beta
 description This extension provides an interactive 3D segmentation tool.
 
 # Space separated list of urls
-screenshoturls http://www.slicer.org/slicerWiki/images/thumb/2/2c/DrawLabel.png/500px-DrawLabel.png http://www.na-mic.org/Wiki/images/thumb/d/d0/TendonSegment.png/800px-TendonSegment.png http://www.na-mic.org/Wiki/images/thumb/b/b8/FiducialSnapshotX.png/800px-FiducialSnapshotX.png
+screenshoturls https://www.slicer.org/slicerWiki/images/thumb/2/2c/DrawLabel.png/500px-DrawLabel.png https://www.na-mic.org/Wiki/images/thumb/d/d0/TendonSegment.png/800px-TendonSegment.png https://www.na-mic.org/Wiki/images/thumb/b/b8/FiducialSnapshotX.png/800px-FiducialSnapshotX.png
 
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 1

--- a/CarreraSlice.s4ext
+++ b/CarreraSlice.s4ext
@@ -28,7 +28,7 @@ contributors Ivan Kolesov, Liangjia Zhu, Allen Tannenbaum (Stony Brook Universit
 category Segmentation
 
 # url to icon (png, size 128x128 pixels)
-iconurl http://wiki.slicer.org/slicerWiki/images/2/2a/CarreraSliceEffect.png
+iconurl https://wiki.slicer.org/slicerWiki/images/2/2a/CarreraSliceEffect.png
 
 # Give people an idea what to expect from this code
 #  - Is it just a test or something you stand behind?

--- a/CarreraSlice.s4ext
+++ b/CarreraSlice.s4ext
@@ -18,7 +18,7 @@ depends NA
 build_subdirectory .
 
 # homepage
-homepage http://wiki.slicer.org/slicerWiki/index.php/Documentation/Nightly/Modules/CarreraSliceInteractiveSegmenter
+homepage https://wiki.slicer.org/slicerWiki/index.php/Documentation/Nightly/Modules/CarreraSliceInteractiveSegmenter
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
 # For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)

--- a/ChangeTracker.s4ext
+++ b/ChangeTracker.s4ext
@@ -38,7 +38,7 @@ status      Work in progress
 description ChangeTracker is a software tool for quantification of the subtle changes in pathology. The module provides a workflow pipeline that combines user input with the medical data. As a result we provide quantitative volumetric measurements of growth/shrinkage together with the volume rendering of the tumor and color-coded visualization of the tumor growth/shrinkage.
 
 # Space separated list of urls
-screenshoturls http://www.slicer.org/slicerWiki/images/8/8e/Slicer4_ChangeTracker_Ad.png
+screenshoturls https://www.slicer.org/slicerWiki/images/8/8e/Slicer4_ChangeTracker_Ad.png
 
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 1

--- a/ChangeTracker.s4ext
+++ b/ChangeTracker.s4ext
@@ -18,7 +18,7 @@ depends     NA
 build_subdirectory .
 
 # homepage
-homepage    http://wiki.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/ChangeTracker
+homepage    https://wiki.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/ChangeTracker
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
 # For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)

--- a/ChangeTracker.s4ext
+++ b/ChangeTracker.s4ext
@@ -28,7 +28,7 @@ contributors Andrey Fedorov (SPL), Kilian Pohl (SPL), Peter Black (BWH), Jean-Ch
 category    Wizards
 
 # url to icon (png, size 128x128 pixels)
-iconurl     http://www.slicer.org/slicerWiki/images/b/b9/ChangeTracker_logo.png
+iconurl     https://www.slicer.org/slicerWiki/images/b/b9/ChangeTracker_logo.png
 
 # Give people an idea what to expect from this code
 #  - Is it just a test or something you stand beind?

--- a/Chest_Imaging_Platform.s4ext
+++ b/Chest_Imaging_Platform.s4ext
@@ -4,7 +4,7 @@ contributors Applied Chest Imaging Laboratory, Brigham and Women's Hospital
 depends NA
 description Chest Imaging Platform is an extension for quantitative CT imaging biomarkers for lung diseases. This work is funded by the National Heart, Lung, And Blood Institute of the National  Institutes of Health under Award Number R01HL116931. The content is solely the responsibility of the authors and does not necessarily represent the official views of the National Institutes of Health.
 enabled 1
-homepage http://www.chestimagingplatform.org
+homepage https://chestimagingplatform.org/
 iconurl https://raw.githubusercontent.com/acil-bwh/SlicerCIP/master/Resources/SlicerCIPLogo.png
 scm git
 scmrevision develop

--- a/CurveMaker.s4ext
+++ b/CurveMaker.s4ext
@@ -18,7 +18,7 @@ depends NA
 build_subdirectory .
 
 # homepage
-homepage http://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/CurveMaker
+homepage https://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/CurveMaker
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
 # For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)

--- a/CurveMaker.s4ext
+++ b/CurveMaker.s4ext
@@ -28,7 +28,7 @@ contributors Junichi Tokuda (BWH)
 category Informatics
 
 # url to icon (png, size 128x128 pixels)
-iconurl http://www.slicer.org/slicerWiki/images/b/b7/CurveMakerIcon.png
+iconurl https://www.slicer.org/slicerWiki/images/b/b7/CurveMakerIcon.png
 
 # Give people an idea what to expect from this code
 #  - Is it just a test or something you stand behind?

--- a/CurveMaker.s4ext
+++ b/CurveMaker.s4ext
@@ -38,7 +38,7 @@ status
 description This is a module to generate a curve based on a list of fiducial points.
 
 # Space separated list of urls
-screenshoturls http://www.slicer.org/slicerWiki/images/0/0b/Slicer4-CurveMaker-GUI.png
+screenshoturls https://www.slicer.org/slicerWiki/images/0/0b/Slicer4-CurveMaker-GUI.png
 
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 1

--- a/DRRGenerator.s4ext
+++ b/DRRGenerator.s4ext
@@ -18,7 +18,7 @@ depends NA
 build_subdirectory .
 
 # homepage
-homepage https://slicerdrrregistration.000webhostapp.com/drrgenerator
+homepage https://github.com/lassoan/SlicerDRRGenerator#readme
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
 # For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)
@@ -28,7 +28,7 @@ contributors Lance Levine
 category Filtering
 
 # url to icon (png, size 128x128 pixels)
-iconurl https://slicerdrrregistration.000webhostapp.com/wp-content/uploads/2020/01/DRRGenerator.png
+iconurl https://raw.githubusercontent.com/lassoan/SlicerDRRGenerator/master/DRRGenerator.png
 
 # Give people an idea what to expect from this code
 #  - Is it just a test or something you stand behind?
@@ -38,7 +38,7 @@ status
 description This extension allows the user to generate DRRs via a highly customizable GUI
 
 # Space separated list of urls
-screenshoturls https://slicerdrrregistration.000webhostapp.com/wp-content/uploads/2020/01/screenshot-1024x556.png
+screenshoturls
 
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 1

--- a/DSCMRIAnalysis.s4ext
+++ b/DSCMRIAnalysis.s4ext
@@ -28,7 +28,7 @@ contributors Andrew Beers (MGH), Jayashree Kalpathy-Cramer (MGH), Xiao Da (MGH)
 category    Quantification
 
 # url to icon (png, size 128x128 pixels)
-iconurl     http://slicer.org/slicerWiki/images/9/92/DSC_logo_Resized.png
+iconurl     https://slicer.org/slicerWiki/images/9/92/DSC_logo_Resized.png
 
 # Give people an idea what to expect from this code
 #  - Is it just a test or something you stand behind?

--- a/DSCMRIAnalysis.s4ext
+++ b/DSCMRIAnalysis.s4ext
@@ -38,7 +38,7 @@ status      Beta
 description Analysis of Dynamic Susceptibility Contrast (DSC) MRI.
 
 # Space separated list of urls
-screenshoturls http://slicer.org/slicerWiki/images/e/e8/DSC_GUI_V0.png
+screenshoturls https://slicer.org/slicerWiki/images/e/e8/DSC_GUI_V0.png
 
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 1

--- a/DSCMRIAnalysis.s4ext
+++ b/DSCMRIAnalysis.s4ext
@@ -18,7 +18,7 @@ depends     NA
 build_subdirectory .
 
 # homepage
-homepage    http://slicer.org/slicerWiki/index.php/Documentation/Nightly/Modules/DSC_MRI_Analysis
+homepage    https://slicer.org/slicerWiki/index.php/Documentation/Nightly/Modules/DSC_MRI_Analysis
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
 # For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)

--- a/DatabaseInteractor.s4ext
+++ b/DatabaseInteractor.s4ext
@@ -28,7 +28,7 @@ contributors Clement Mirabel (University of Michigan), Juan Carlos Prieto (UNC)
 category Web System Tools
 
 # url to icon (png, size 128x128 pixels)
-iconurl https://www.slicer.org/w/images/7/7f/DatabaseInteractor_Logo.png
+iconurl https://www.slicer.org/slicerWiki/images/7/7f/DatabaseInteractor_Logo.png
 
 # Give people an idea what to expect from this code
 #  - Is it just a test or something you stand behind?
@@ -38,7 +38,7 @@ status
 description This extension can interact with online data in a database and local folders.
 
 # Space separated list of urls
-screenshoturls https://www.slicer.org/w/images/1/1f/FullView_DatabaseInteractor.png
+screenshoturls https://www.slicer.org/slicerWiki/images/1/1f/FullView_DatabaseInteractor.png
 
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 1

--- a/DatabaseInteractor.s4ext
+++ b/DatabaseInteractor.s4ext
@@ -18,7 +18,7 @@ depends NA
 build_subdirectory .
 
 # homepage
-homepage http://slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/DatabaseInteractor
+homepage https://slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/DatabaseInteractor
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
 # For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)

--- a/DebuggingTools.s4ext
+++ b/DebuggingTools.s4ext
@@ -18,7 +18,7 @@ depends     NA
 build_subdirectory .
 
 # homepage
-homepage    http://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/DebuggingTools
+homepage    https://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/DebuggingTools
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
 # For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)

--- a/DeveloperToolsForExtensions.s4ext
+++ b/DeveloperToolsForExtensions.s4ext
@@ -18,7 +18,7 @@ depends     NA
 build_subdirectory .
 
 # homepage
-homepage    http://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/DeveloperToolsForExtensions
+homepage    https://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/DeveloperToolsForExtensions
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
 # For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)

--- a/DeveloperToolsForExtensions.s4ext
+++ b/DeveloperToolsForExtensions.s4ext
@@ -38,7 +38,7 @@ status
 description This extension offers different tools to help developers when they create Slicer extension.
 
 # Space separated list of urls
-screenshoturls http://www.slicer.org/slicerWiki/images/5/54/SlicerExtension-SlicerDeveloperToolsForExtensions-Screenshot.png http://www.slicer.org/slicerWiki/images/d/db/SlicerExtensions-SlicerDeveloperToolsForExtensions-Screenshot-panels.png
+screenshoturls https://www.slicer.org/slicerWiki/images/5/54/SlicerExtension-SlicerDeveloperToolsForExtensions-Screenshot.png https://www.slicer.org/slicerWiki/images/d/db/SlicerExtensions-SlicerDeveloperToolsForExtensions-Screenshot-panels.png
 
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 1

--- a/DiffusionQC.s4ext
+++ b/DiffusionQC.s4ext
@@ -13,7 +13,8 @@ contributors Tashrif Billah, Isaiah Norton, Yogesh Rathi, Sylvain Bouix (Brigham
 category Diffusion
 
 iconurl https://github.com/pnlbwh/SlicerDiffusionQC/raw/master/Misc/DiffusionQC-icon-128x128.png
-screenshoturls https://raw.githubusercontent.com/pnlbwh/SlicerDiffusionQC/master/Misc/DiffusionQC-screenshot.jpg
+
+screenshoturls https://raw.githubusercontent.com/pnlbwh/SlicerDiffusionQC/master/Misc/DiffusionQC-screenshot.png
 
 status WIP
 

--- a/EasyClip.s4ext
+++ b/EasyClip.s4ext
@@ -38,7 +38,7 @@ status
 description This Module is used to clip one or different 3D Models according to a predetermined plane. Plane can be saved to be reused for other models. After clipping, the models are closed and can be saved as new 3D Models.
 
 # Space separated list of urls
-screenshoturls http://www.slicer.org/slicerWiki/images/1/1b/EasyClipPlanePosition.png
+screenshoturls https://www.slicer.org/slicerWiki/images/1/1b/EasyClipPlanePosition.png
 
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 1

--- a/EasyClip.s4ext
+++ b/EasyClip.s4ext
@@ -18,7 +18,7 @@ depends NA
 build_subdirectory .
 
 # homepage
-homepage http://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/EasyClip
+homepage https://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/EasyClip
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
 # For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)

--- a/ErodeDilateLabel.s4ext
+++ b/ErodeDilateLabel.s4ext
@@ -18,7 +18,7 @@ depends     NA
 build_subdirectory .
 
 # homepage
-homepage    http://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/ErodeDilateLabel
+homepage    https://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/ErodeDilateLabel
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
 # For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)

--- a/ErodeDilateLabel.s4ext
+++ b/ErodeDilateLabel.s4ext
@@ -38,7 +38,7 @@ status
 description This extension applies binary erosion and dilation to label maps. The extension uses binary erosion and dilation filters in ITK based on N.Nikopoulos et al. An efficient algorithm for 3d binary morphological transformations with 3d structuring elements for arbitrary size and shape. IEEE Transactions on Image Processing. Vol. 9. No. 3. 2000. pp. 283-286.
 
 # Space separated list of urls
-screenshoturls http://www.slicer.org/slicerWiki/images/d/df/Slicer4-ErodeDilateLabel-GUI.png
+screenshoturls https://www.slicer.org/slicerWiki/images/d/df/Slicer4-ErodeDilateLabel-GUI.png
 
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 1

--- a/ErodeDilateLabel.s4ext
+++ b/ErodeDilateLabel.s4ext
@@ -28,7 +28,7 @@ contributors Junichi Tokuda (Brigham and Women's Hospital)
 category    Filtering.Morphology
 
 # url to icon (png, size 128x128 pixels)
-iconurl     http://www.slicer.org/slicerWiki/images/a/ac/ErodeDilateLabelIcon.png
+iconurl     https://www.slicer.org/slicerWiki/images/a/ac/ErodeDilateLabelIcon.png
 
 # Give people an idea what to expect from this code
 #  - Is it just a test or something you stand beind?

--- a/FilmDosimetryAnalysis.s4ext
+++ b/FilmDosimetryAnalysis.s4ext
@@ -28,7 +28,7 @@ contributors Csaba Pinter (PerkLab, Queen's University), Alec Robinson (PerkLab,
 category Radiotherapy
 
 # url to icon (png, size 128x128 pixels)
-iconurl http://www.slicer.org/slicerWiki/images/1/16/FilmDosimetry_Logo_128x128.png
+iconurl https://www.slicer.org/slicerWiki/images/1/16/FilmDosimetry_Logo_128x128.png
 
 # Give people an idea what to expect from this code
 #  - Is it just a test or something you stand behind?

--- a/FilmDosimetryAnalysis.s4ext
+++ b/FilmDosimetryAnalysis.s4ext
@@ -18,7 +18,7 @@ depends SlicerRT
 build_subdirectory .
 
 # homepage
-homepage http://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Modules/FilmDosimetry
+homepage https://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Modules/FilmDosimetry
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
 # For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)

--- a/GelDosimetryAnalysis.s4ext
+++ b/GelDosimetryAnalysis.s4ext
@@ -18,7 +18,7 @@ depends     SlicerRT
 build_subdirectory .
 
 # homepage
-homepage    http://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Modules/GelDosimetry
+homepage    https://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Modules/GelDosimetry
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
 # For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)

--- a/GelDosimetryAnalysis.s4ext
+++ b/GelDosimetryAnalysis.s4ext
@@ -38,7 +38,7 @@ status
 description Slicelet covering the gel dosimetry analysis workflow used in commissioning new radiation techniques and to validate the accuracy of radiation treatment by enabling visual comparison of the planned dose to the delivered dose, where correspondence between the two dose distributions is achieved using embedded landmarks. Gel dosimetry is based on imaging chemical systems spatially fixed in gelatin, which exhibit a detectable change upon irradiation.
 
 # Space separated list of urls
-screenshoturls http://www.slicer.org/slicerWiki/images/8/83/GelDosimetrySlicelet_0.1_LandmarkRegistrationStep.png http://www.slicer.org/slicerWiki/images/6/68/GelDosimetrySlicelet_0.1_CalibrationCurvesAligned.png http://www.slicer.org/slicerWiki/images/5/51/GelDosimetrySlicelet_0.1_OdVsDoseCurve.png
+screenshoturls https://www.slicer.org/slicerWiki/images/8/83/GelDosimetrySlicelet_0.1_LandmarkRegistrationStep.png https://www.slicer.org/slicerWiki/images/6/68/GelDosimetrySlicelet_0.1_CalibrationCurvesAligned.png https://www.slicer.org/slicerWiki/images/5/51/GelDosimetrySlicelet_0.1_OdVsDoseCurve.png
 
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 1

--- a/GelDosimetryAnalysis.s4ext
+++ b/GelDosimetryAnalysis.s4ext
@@ -28,7 +28,7 @@ contributors Csaba Pinter (PerkLab, Queen's University), Jennifer Andrea (PerkLa
 category    Radiotherapy
 
 # url to icon (png, size 128x128 pixels)
-iconurl     http://www.slicer.org/slicerWiki/images/f/f1/GelDosimetry_Logo_128x128.png
+iconurl     https://www.slicer.org/slicerWiki/images/f/f1/GelDosimetry_Logo_128x128.png
 
 # Give people an idea what to expect from this code
 #  - Is it just a test or something you stand behind?

--- a/GyroGuide.s4ext
+++ b/GyroGuide.s4ext
@@ -28,7 +28,7 @@ contributors Ruifeng Chen, Luping Fang, Qing Pan (College of Information Enginee
 category    IGT
 
 # url to icon (png, size 128x128 pixels)
-iconurl     http://www.slicer.org/slicerWiki/images/a/a7/GyroGuide.png
+iconurl     https://www.slicer.org/slicerWiki/images/a/a7/GyroGuide.png
 
 # Give people an idea what to expect from this code
 #  - Is it just a test or something you stand beind?

--- a/GyroGuide.s4ext
+++ b/GyroGuide.s4ext
@@ -18,7 +18,7 @@ depends     NA
 build_subdirectory .
 
 # homepage
-homepage    http://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/GyroGuide
+homepage    https://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/GyroGuide
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
 # For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)

--- a/GyroGuide.s4ext
+++ b/GyroGuide.s4ext
@@ -38,7 +38,7 @@ status Beta
 description GyroGuide determines the trajectory angle and depth of puncture path, and transmits the calculated information to the probe for real time navigation.
 
 # Space separated list of urls
-screenshoturls http://www.slicer.org/slicerWiki/index.php/File:GyroGuide-Step-2.png
+screenshoturls https://www.slicer.org/slicerWiki/images/8/80/GyroGuide-Step-2.png
 
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 1

--- a/ImageMaker.s4ext
+++ b/ImageMaker.s4ext
@@ -18,7 +18,7 @@ depends     NA
 build_subdirectory .
 
 # homepage
-homepage    http://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/ImageMaker
+homepage    https://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/ImageMaker
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
 # For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)

--- a/ImageMaker.s4ext
+++ b/ImageMaker.s4ext
@@ -38,7 +38,7 @@ status
 description This is a CLI module to create an image from scratch.
 
 # Space separated list of urls
-screenshoturls http://www.slicer.org/slicerWiki/images/8/81/ImageMaker.png
+screenshoturls https://www.slicer.org/slicerWiki/images/8/81/ImageMaker.png
 
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 1

--- a/ImageMaker.s4ext
+++ b/ImageMaker.s4ext
@@ -28,7 +28,7 @@ contributors Julien Finet (Kitware)
 category    Developer Tools
 
 # url to icon (png, size 128x128 pixels)
-iconurl     http://www.slicer.org/slicerWiki/images/e/e5/QuickToolsLogo.png
+iconurl     https://www.slicer.org/slicerWiki/images/e/e5/QuickToolsLogo.png
 
 # Give people an idea what to expect from this code
 #  - Is it just a test or something you stand beind?

--- a/IntensitySegmenter.s4ext
+++ b/IntensitySegmenter.s4ext
@@ -38,7 +38,7 @@ status  beta
 description IntensitySegmenter is a simple tool that segments an image according to intensity value. It is mainly used to segment CT scans using the Hounsfield scale but the ranges of intensities and their corresponding labels can be specified in an input text file.
 
 # Space separated list of urls
-screenshoturls http://wiki.slicer.org/slicerWiki/images/7/7c/IntensitySegmenter-OutputScreenshot.png
+screenshoturls https://wiki.slicer.org/slicerWiki/images/7/7c/IntensitySegmenter-OutputScreenshot.png
 
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 1

--- a/IntensitySegmenter.s4ext
+++ b/IntensitySegmenter.s4ext
@@ -18,7 +18,7 @@ depends     NA
 build_subdirectory .
 
 # homepage
-homepage   http://www.nitrc.org/projects/dentaltools/
+homepage   https://www.nitrc.org/projects/dentaltools/
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
 # For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)

--- a/IntensitySegmenter.s4ext
+++ b/IntensitySegmenter.s4ext
@@ -28,7 +28,7 @@ contributors Pengdong Xiao (Department of Orthodontics, UNC), Beatriz Paniagua (
 category    Segmentation
 
 # url to icon (png, size 128x128 pixels)
-iconurl     http://wiki.slicer.org/slicerWiki/images/f/f6/IntensitySegmenterIcon.png
+iconurl     https://wiki.slicer.org/slicerWiki/images/f/f6/IntensitySegmenterIcon.png
 
 # Give people an idea what to expect from this code
 #  - Is it just a test or something you stand beind?

--- a/MHubRunner.s4ext
+++ b/MHubRunner.s4ext
@@ -18,7 +18,6 @@ scmrevision main
 build_subdirectory .
 
 # homepage
-# TODO: add mhub.ai website once ready
 homepage https://mhub.ai/
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
@@ -28,7 +27,7 @@ contributors Leonard Nürnberg (AIM, Mass General Brigham)
 category Examples
 
 # url to icon (png, size 128x128 pixels)
-https://mhub.ai/slicer/SlicerMHubRunner.png
+iconurl https://mhub.ai/slicer/SlicerMHubRunner.png
 
 # Give people an idea what to expect from this code
 #  - Is it just a test or something you stand behind?

--- a/MONAIViz.s4ext
+++ b/MONAIViz.s4ext
@@ -38,7 +38,7 @@ status
 description This extension helps to run chain of MONAI transforms and visualize every stage over an image/label. See more information in <a href="https://github.com/Project-MONAI/MONAILabel">MONAILabel documentation</a>.
 
 # Space separated list of urls
-screenshoturls https://github.com/Project-MONAI/SlicerMONAIViz/raw/main/Screenshots/1.jpg https://github.com/Project-MONAI/SlicerMONAIViz/raw/main/Screenshots/2.jpg https://github.com/Project-MONAI/SlicerMONAIViz/raw/main/Screenshots/3.jpg https://github.com/Project-MONAI/SlicerMONAIViz/raw/main/Screenshots/4.jpg
+screenshoturls https://github.com/Project-MONAI/SlicerMONAIViz/raw/main/Screenshots/1.jpg https://github.com/Project-MONAI/SlicerMONAIViz/raw/main/Screenshots/2.jpg https://github.com/Project-MONAI/SlicerMONAIViz/raw/main/Screenshots/3.jpg https://github.com/Project-MONAI/SlicerMONAIViz/raw/main/Screenshots/4.png
 
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 1

--- a/MarkupsToModel.s4ext
+++ b/MarkupsToModel.s4ext
@@ -18,7 +18,7 @@ depends NA
 build_subdirectory .
 
 # homepage
-homepage https://github.com/SlicerIGT/MarkupsToModel
+homepage https://github.com/SlicerIGT/SlicerMarkupsToModel#readme
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
 # For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)

--- a/MatlabBridge.s4ext
+++ b/MatlabBridge.s4ext
@@ -38,7 +38,7 @@ status
 description The Matlab Bridge extension allows running Matlab scripts as command-line interface (CLI) modules directly from 3D Slicer. The only prerequisites for running Matlab scripts are having this extension and Matlab installed on the 3D Slicer computer (building of 3D Slicer, MEX files, etc. is not needed).
 
 # Space separated list of urls
-screenshoturls http://www.slicer.org/slicerWiki/images/2/2f/MatlabBridgeScreenshot1.png http://www.slicer.org/slicerWiki/images/1/16/MatlabBridgeScreenshot2.png http://www.slicer.org/slicerWiki/images/b/b9/MatlabBridgeScreenshot3.png
+screenshoturls https://www.slicer.org/slicerWiki/images/2/2f/MatlabBridgeScreenshot1.png https://www.slicer.org/slicerWiki/images/1/16/MatlabBridgeScreenshot2.png https://www.slicer.org/slicerWiki/images/b/b9/MatlabBridgeScreenshot3.png
 
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 1

--- a/MatlabBridge.s4ext
+++ b/MatlabBridge.s4ext
@@ -28,7 +28,7 @@ contributors Andras Lasso (PerkLab, Queen's University), Jean-Christophe Fillion
 category    Developer Tools
 
 # url to icon (png, size 128x128 pixels)
-iconurl     http://www.slicer.org/slicerWiki/images/e/e8/MatlabBridgeLogo.png
+iconurl     https://www.slicer.org/slicerWiki/images/e/e8/MatlabBridgeLogo.png
 
 # Give people an idea what to expect from this code
 #  - Is it just a test or something you stand behind?

--- a/MatlabBridge.s4ext
+++ b/MatlabBridge.s4ext
@@ -18,7 +18,7 @@ depends     SlicerOpenIGTLink
 build_subdirectory .
 
 # homepage
-homepage    http://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/MatlabBridge
+homepage    https://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/MatlabBridge
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
 # For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)

--- a/MeshStatisticsExtension.s4ext
+++ b/MeshStatisticsExtension.s4ext
@@ -18,7 +18,7 @@ depends ModelToModelDistance
 build_subdirectory .
 
 # homepage
-homepage http://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/MeshStatistics
+homepage https://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/MeshStatistics
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
 # For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)

--- a/MeshStatisticsExtension.s4ext
+++ b/MeshStatisticsExtension.s4ext
@@ -38,7 +38,7 @@ status
 description Mesh Statistics allows users to compute descriptive statistics over specific and predefined regions
 
 # Space separated list of urls
-screenshoturls http://www.slicer.org/slicerWiki/index.php/File:MeshStatistics_Interface.png
+screenshoturls https://www.slicer.org/slicerWiki/index.php/File:MeshStatistics_Interface.png
 
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 1

--- a/MeshToLabelMap.s4ext
+++ b/MeshToLabelMap.s4ext
@@ -18,7 +18,7 @@ depends NA
 build_subdirectory .
 
 # homepage
-homepage http://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/MeshToLabelMap
+homepage https://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/MeshToLabelMap
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
 # For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)

--- a/MeshToLabelMap.s4ext
+++ b/MeshToLabelMap.s4ext
@@ -38,7 +38,7 @@ status Release
 description This extension computes a label map from a 3D model.
 
 # Space separated list of urls
-screenshoturls http://slicer.org/slicerWiki/images/thumb/5/54/MeshToLabelMapScreenshot.png/800px-MeshToLabelMapScreenshot.png
+screenshoturls https://slicer.org/slicerWiki/images/thumb/5/54/MeshToLabelMapScreenshot.png/800px-MeshToLabelMapScreenshot.png
 
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 1

--- a/ModelClip.s4ext
+++ b/ModelClip.s4ext
@@ -38,7 +38,7 @@ status
 description This is an extension module to set the osteotomy trajectory with multiple planes and clip with just one click.
 
 # Space separated list of urls
-screenshoturls http://www.slicer.org/slicerWiki/index.php/File:ModelClipScreenShot.png
+screenshoturls https://www.slicer.org/slicerWiki/index.php/File:ModelClipScreenShot.png
 
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 1

--- a/ModelClip.s4ext
+++ b/ModelClip.s4ext
@@ -28,7 +28,7 @@ contributors Jun LIN, Xiaojun CHEN, Ph.D (SJTU)
 category Surface Models
 
 # url to icon (png, size 128x128 pixels)
-iconurl http://www.slicer.org/slicerWiki/index.php/File:ModelClipIcon.png
+iconurl https://www.slicer.org/slicerWiki/images/b/bd/ModelClipIcon.png
 
 # Give people an idea what to expect from this code
 #  - Is it just a test or something you stand behind?

--- a/ModelClip.s4ext
+++ b/ModelClip.s4ext
@@ -18,7 +18,7 @@ depends NA
 build_subdirectory .
 
 # homepage
-homepage http://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/ModelClip
+homepage https://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/ModelClip
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
 # For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)

--- a/ModelToModelDistance.s4ext
+++ b/ModelToModelDistance.s4ext
@@ -28,7 +28,7 @@ contributors Francois Budin (UNC), Juliette Pera (UNC), Beatriz Paniagua (UNC)
 category Quantification
 
 # url to icon (png, size 128x128 pixels)
-iconurl http://slicer.org/slicerWiki/images/4/43/Slicer4ExtensionModelToModelDistance.png
+iconurl https://slicer.org/slicerWiki/images/4/43/Slicer4ExtensionModelToModelDistance.png
 
 # Give people an idea what to expect from this code
 #  - Is it just a test or something you stand behind?

--- a/ModelToModelDistance.s4ext
+++ b/ModelToModelDistance.s4ext
@@ -38,7 +38,7 @@ status
 description This extension computes the distance between two 3D models
 
 # Space separated list of urls
-screenshoturls http://www.slicer.org/slicerWiki/images/thumb/7/7a/Slicer4Extensions-ModelToModelDistanceOriginalShapes.png/800px-Slicer4Extensions-ModelToModelDistanceOriginalShapes.png
+screenshoturls https://www.slicer.org/slicerWiki/images/thumb/7/7a/Slicer4Extensions-ModelToModelDistanceOriginalShapes.png/800px-Slicer4Extensions-ModelToModelDistanceOriginalShapes.png
 
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 1

--- a/NvidiaAIAssistedAnnotation.s4ext
+++ b/NvidiaAIAssistedAnnotation.s4ext
@@ -28,7 +28,7 @@ contributors Sachidanand Alle (NVIDIA)
 category Segmentation
 
 # url to icon (png, size 128x128 pixels)
-iconurl https://raw.githubusercontent.com/NVIDIA/ai-assisted-annotation-client/master/slicer-plugin/snapshot.jpg https://raw.githubusercontent.com/NVIDIA/ai-assisted-annotation-client/master/slicer-plugin/snapshot-annotation-points-liver.jpg https://raw.githubusercontent.com/NVIDIA/ai-assisted-annotation-client/master/slicer-plugin/snapshot-annotation-result-liver.jpg https://raw.githubusercontent.com/NVIDIA/ai-assisted-annotation-client/master/slicer-plugin/snapshot-segmentation-result-liver.jpg
+iconurl https://raw.githubusercontent.com/NVIDIA/ai-assisted-annotation-client/master/slicer-plugin/NvidiaAIAssistedAnnotation.png
 
 # Give people an idea what to expect from this code
 #  - Is it just a test or something you stand behind?
@@ -38,7 +38,7 @@ status
 description This extension offers automatic segmentation using NVIDIA AI-Assisted Annotation framework (Powered by the Clara Train SDK).
 
 # Space separated list of urls
-screenshoturls https://raw.githubusercontent.com/NVIDIA/ai-assisted-annotation-client/master/slicer-plugin/snapshot.png
+screenshoturls https://raw.githubusercontent.com/NVIDIA/ai-assisted-annotation-client/master/slicer-plugin/snapshot.jpg https://raw.githubusercontent.com/NVIDIA/ai-assisted-annotation-client/master/slicer-plugin/snapshot-annotation-points-liver.jpg https://raw.githubusercontent.com/NVIDIA/ai-assisted-annotation-client/master/slicer-plugin/snapshot-annotation-result-liver.jpg https://raw.githubusercontent.com/NVIDIA/ai-assisted-annotation-client/master/slicer-plugin/snapshot-segmentation-result-liver.jpg
 
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 1

--- a/OpenDose3D.s4ext
+++ b/OpenDose3D.s4ext
@@ -38,7 +38,7 @@ status stable
 description This module implements full 3D dosimetry for molecular radiotherapy on multiple time points.
 
 # Space separated list of urls
-screenshoturls https://gitlab.com/opendose/opendose3d/-/raw/develop/Dosimetry4D/Resources/Icons/ss1.png https://gitlab.com/opendose/opendose3d/-/raw/develop/Dosimetry4D/Resources/Icons/ss2.png
+screenshoturls https://gitlab.com/opendose/opendose3d/-/raw/develop/OpenDose3D/Resources/Icons/ss1.png https://gitlab.com/opendose/opendose3d/-/raw/develop/OpenDose3D/Resources/Icons/ss2.png
 
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 1

--- a/OsteotomyPlanner.s4ext
+++ b/OsteotomyPlanner.s4ext
@@ -28,7 +28,7 @@ contributors Sam Horvath (Kitware Inc.), Johan Andruejol (Kitware Inc.)
 category Osteotomy Planning
 
 # url to icon (png, size 128x128 pixels)
-iconurl https://raw.githubusercontent.com/KitwareMedical/OsteotomyPlanner/master/Planner/Resources/Icons/Planner.png
+iconurl https://github.com/KitwareMedical/OsteotomyPlanner/blob/master/ReplayPlan/Resources/Icons/ReplayPlan.png
 
 # Give people an idea what to expect from this code
 #  - Is it just a test or something you stand behind?

--- a/PBNRR.s4ext
+++ b/PBNRR.s4ext
@@ -38,7 +38,7 @@ status
 description This Slicer extension non-rigid registers a moving to a fixed MRI using a linear homogeneous bio-mechanical model to compute a dense deformation field that defines a transformation for every point in the fixed to the moving image.
 
 # Space separated list of urls
-screenshoturls http://www.slicer.org/slicerWiki/images/6/63/Case1_input.png http://www.slicer.org/slicerWiki/images/a/a4/Case1_output.png http://www.slicer.org/slicerWiki/images/d/db/PBNRR_panel.png
+screenshoturls https://www.slicer.org/slicerWiki/images/6/63/Case1_input.png https://www.slicer.org/slicerWiki/images/a/a4/Case1_output.png https://www.slicer.org/slicerWiki/images/d/db/PBNRR_panel.png
 
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 1

--- a/PET-IndiC.s4ext
+++ b/PET-IndiC.s4ext
@@ -38,7 +38,7 @@ status
 description The PET-IndiC Extension allows for fast segmentation of regions of interest and calculation of quantitative indices.
 
 # Space separated list of urls
-screenshoturls http://www.slicer.org/slicerWiki/images/3/32/PET-IndiC_Screenshot1.png http://www.slicer.org/slicerWiki/images/8/8b/PET-IndiC_Screenshot3.png http://www.slicer.org/slicerWiki/images/8/8e/PET-IndiC_Screenshot5.png
+screenshoturls https://www.slicer.org/slicerWiki/images/3/32/PET-IndiC_Screenshot1.png https://www.slicer.org/slicerWiki/images/8/8b/PET-IndiC_Screenshot3.png https://www.slicer.org/slicerWiki/images/8/8e/PET-IndiC_Screenshot5.png
 
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 1

--- a/PET-IndiC.s4ext
+++ b/PET-IndiC.s4ext
@@ -18,7 +18,7 @@ depends     NA
 build_subdirectory .
 
 # homepage
-homepage    http://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/PET-IndiC
+homepage    https://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/PET-IndiC
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
 # For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)

--- a/PETCPhantom.s4ext
+++ b/PETCPhantom.s4ext
@@ -18,7 +18,7 @@ depends     NA
 build_subdirectory .
 
 # homepage
-homepage    https://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/PETCPhantom
+homepage    https://www.slicer.org/wiki/Documentation/Nightly/Modules/PETCPhantomAnalysis
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
 # For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)

--- a/PETCPhantom.s4ext
+++ b/PETCPhantom.s4ext
@@ -18,7 +18,7 @@ depends     NA
 build_subdirectory .
 
 # homepage
-homepage    http://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/PETCPhantom
+homepage    https://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/PETCPhantom
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
 # For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)

--- a/PETDICOMExtension.s4ext
+++ b/PETDICOMExtension.s4ext
@@ -38,7 +38,7 @@ status
 description The PET DICOM Extension provides tools to import PET Standardized Uptake Value images from DICOM into Slicer.
 
 # Space separated list of urls
-screenshoturls http://wiki.slicer.org/slicerWiki/images/thumb/2/2e/SUV_Factor_Calculator_GUI.png/418px-SUV_Factor_Calculator_GUI.png http://wiki.slicer.org/slicerWiki/images/thumb/2/29/DICOM_Browser_RWVM_Plugin.png/800px-DICOM_Browser_RWVM_Plugin.png http://wiki.slicer.org/slicerWiki/images/thumb/4/43/DICOM_Browser_PET_SUV_Plugin.png/800px-DICOM_Browser_PET_SUV_Plugin.png
+screenshoturls https://wiki.slicer.org/slicerWiki/images/thumb/2/2e/SUV_Factor_Calculator_GUI.png/418px-SUV_Factor_Calculator_GUI.png https://wiki.slicer.org/slicerWiki/images/thumb/2/29/DICOM_Browser_RWVM_Plugin.png/800px-DICOM_Browser_RWVM_Plugin.png https://wiki.slicer.org/slicerWiki/images/thumb/4/43/DICOM_Browser_PET_SUV_Plugin.png/800px-DICOM_Browser_PET_SUV_Plugin.png
 
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 1

--- a/PETDICOMExtension.s4ext
+++ b/PETDICOMExtension.s4ext
@@ -18,7 +18,7 @@ depends     NA
 build_subdirectory .
 
 # homepage
-homepage    http://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/PETDICOM
+homepage    https://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/PETDICOM
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
 # For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)

--- a/PETTumorSegmentation.s4ext
+++ b/PETTumorSegmentation.s4ext
@@ -18,7 +18,7 @@ depends     NA
 build_subdirectory .
 
 # homepage
-homepage    http://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/PETTumorSegmentation
+homepage    https://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/PETTumorSegmentation
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
 # For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)

--- a/PETTumorSegmentation.s4ext
+++ b/PETTumorSegmentation.s4ext
@@ -38,7 +38,7 @@ status
 description Tumor and lymph node segmentation in PET scans
 
 # Space separated list of urls
-screenshoturls http://www.slicer.org/slicerWiki/images/0/04/PETTumorSegmentation_Effect_with_models.png
+screenshoturls https://www.slicer.org/slicerWiki/images/0/04/PETTumorSegmentation_Effect_with_models.png
 
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 1

--- a/ParallelProcessing.s4ext
+++ b/ParallelProcessing.s4ext
@@ -38,7 +38,7 @@ status
 description Manage helper processes to perform background tasks in parallel.
 
 # Space separated list of urls
-screenshoturls https://camo.githubusercontent.com/f32d3911615ff1ff73af2e453fb8d1233f43a831339317618229a6e622859a01/687474703a2f2f696d672e796f75747562652e636f6d2f76692f6c6f3830346352446d70512f302e6a7067
+screenshoturls
 
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 1

--- a/PercutaneousApproachAnalysis.s4ext
+++ b/PercutaneousApproachAnalysis.s4ext
@@ -9,5 +9,5 @@ iconurl https://www.slicer.org/slicerWiki/images/a/ac/PAAlogo-small.png
 scm git
 scmrevision a2a7615ff20ae45462b854172c41cf233b401e30
 scmurl https://github.com/SlicerIGT/PercutaneousApproachAnalysis
-screenshoturls http://www.slicer.org/slicerWiki/images/4/42/Accessibility_clinical.png
+screenshoturls https://www.slicer.org/slicerWiki/images/4/42/Accessibility_clinical.png
 status

--- a/PercutaneousApproachAnalysis.s4ext
+++ b/PercutaneousApproachAnalysis.s4ext
@@ -5,7 +5,7 @@ depends NA
 description The Percutaneous Approach Analysis is used to calculate and visualize the accessibility of liver tumor with a percutaneous approach.
 enabled 1
 homepage https://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/PercutaneousApproachAnalysis
-iconurl http://www.slicer.org/slicerWiki/images/a/ac/PAAlogo-small.png
+iconurl https://www.slicer.org/slicerWiki/images/a/ac/PAAlogo-small.png
 scm git
 scmrevision a2a7615ff20ae45462b854172c41cf233b401e30
 scmurl https://github.com/SlicerIGT/PercutaneousApproachAnalysis

--- a/PercutaneousApproachAnalysis.s4ext
+++ b/PercutaneousApproachAnalysis.s4ext
@@ -4,7 +4,7 @@ contributors Koichiro Murakami (Shiga University of Medical Science, Japan, SPL)
 depends NA
 description The Percutaneous Approach Analysis is used to calculate and visualize the accessibility of liver tumor with a percutaneous approach.
 enabled 1
-homepage http://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/PercutaneousApproachAnalysis
+homepage https://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/PercutaneousApproachAnalysis
 iconurl http://www.slicer.org/slicerWiki/images/a/ac/PAAlogo-small.png
 scm git
 scmrevision a2a7615ff20ae45462b854172c41cf233b401e30

--- a/PerkTutor.s4ext
+++ b/PerkTutor.s4ext
@@ -38,7 +38,7 @@ status
 description This extension holds modules for training of needle interventions and analysis of operator performance.
 
 # Space separated list of urls
-screenshoturls http://www.slicer.org/slicerWiki/images/2/28/PerkTutorScreenshot.png
+screenshoturls https://www.slicer.org/slicerWiki/images/2/28/PerkTutorScreenshot.png
 
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 1

--- a/PerkTutor.s4ext
+++ b/PerkTutor.s4ext
@@ -18,7 +18,7 @@ depends NA
 build_subdirectory .
 
 # homepage
-homepage http://www.perktutor.org/
+homepage https://www.perktutor.org/
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
 # For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)

--- a/PerkTutor.s4ext
+++ b/PerkTutor.s4ext
@@ -28,7 +28,7 @@ contributors Tamas Ungi, Matthew S. Holden (Queen's University)
 category Training
 
 # url to icon (png, size 128x128 pixels)
-iconurl http://www.slicer.org/slicerWiki/images/2/21/PerkTutorLogo.png
+iconurl https://www.slicer.org/slicerWiki/images/2/21/PerkTutorLogo.png
 
 # Give people an idea what to expect from this code
 #  - Is it just a test or something you stand behind?

--- a/PetSpectAnalysis.s4ext
+++ b/PetSpectAnalysis.s4ext
@@ -38,7 +38,7 @@ status
 description First Version of the Pet Spect Analysis Extension
 
 # Space separated list of urls
-screenshoturls http://www.slicer.org/slicerWiki/images/e/e4/ProcessingBlocks.png http://www.slicer.org/slicerWiki/images/7/76/InformationPanel.png http://www.slicer.org/slicerWiki/images/2/2a/VisualizationPanel.png http://www.slicer.org/slicerWiki/images/2/24/CarotidSegmentation.png http://www.slicer.org/slicerWiki/images/b/bb/CarotidSegmentationROI.png http://www.slicer.org/slicerWiki/images/5/51/PTACEstimationIDIF.png http://www.slicer.org/slicerWiki/images/9/98/PTACEstimationPBIF.png http://www.slicer.org/slicerWiki/images/9/90/KMap.png
+screenshoturls https://www.slicer.org/slicerWiki/images/e/e4/ProcessingBlocks.png https://www.slicer.org/slicerWiki/images/7/76/InformationPanel.png https://www.slicer.org/slicerWiki/images/2/2a/VisualizationPanel.png https://www.slicer.org/slicerWiki/images/2/24/CarotidSegmentation.png https://www.slicer.org/slicerWiki/images/b/bb/CarotidSegmentationROI.png https://www.slicer.org/slicerWiki/images/5/51/PTACEstimationIDIF.png https://www.slicer.org/slicerWiki/images/9/98/PTACEstimationPBIF.png https://www.slicer.org/slicerWiki/images/9/90/KMap.png
 
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 1

--- a/PetSpectAnalysis.s4ext
+++ b/PetSpectAnalysis.s4ext
@@ -18,7 +18,7 @@ depends     NA
 build_subdirectory .
 
 # homepage
-homepage    http://gti-fing.github.io/SlicerPetSpectAnalysis
+homepage    https://gti-fing.github.io/SlicerPetSpectAnalysis
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
 # For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)

--- a/PetSpectAnalysis.s4ext
+++ b/PetSpectAnalysis.s4ext
@@ -28,7 +28,7 @@ contributors Martin Bertran, Natalia Martinez Gil, Guillermo Carbajal, Alvaro Go
 category    Nuclear Medicine
 
 # url to icon (png, size 128x128 pixels)
-iconurl     http://www.slicer.org/slicerWiki/images/b/b1/DPetBrainQuantification.png
+iconurl     https://www.slicer.org/slicerWiki/images/b/b1/DPetBrainQuantification.png
 
 # Give people an idea what to expect from this code
 #  - Is it just a test or something you stand behind?

--- a/PickAndPaintExtension.s4ext
+++ b/PickAndPaintExtension.s4ext
@@ -38,7 +38,7 @@ status
 description Pick 'n Paint tool allows users to select ROIs on a reference model and to propagate it over different time point models.
 
 # Space separated list of urls
-screenshoturls http://www.slicer.org/slicerWiki/images/a/ac/Pick%27NPaint_Interface.png
+screenshoturls https://www.slicer.org/slicerWiki/images/a/ac/Pick%27NPaint_Interface.png
 
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 1

--- a/PickAndPaintExtension.s4ext
+++ b/PickAndPaintExtension.s4ext
@@ -18,7 +18,7 @@ depends NA
 build_subdirectory .
 
 # homepage
-homepage http://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/PickAndPaint
+homepage https://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/PickAndPaint
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
 # For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)

--- a/PkModeling.s4ext
+++ b/PkModeling.s4ext
@@ -28,7 +28,7 @@ contributors Yingxuan Zhu (GE), Jim Miller (GE), Andriy Fedorov (BWH), Ming-chin
 category    Quantification
 
 # url to icon (png, size 128x128 pixels)
-iconurl     http://wiki.slicer.org/slicerWiki/images/3/34/PkModeling.png
+iconurl     https://wiki.slicer.org/slicerWiki/images/3/34/PkModeling.png
 
 # Give people an idea what to expect from this code
 #  - Is it just a test or something you stand beind?

--- a/PortPlacement.s4ext
+++ b/PortPlacement.s4ext
@@ -18,7 +18,7 @@ depends NA
 build_subdirectory inner-build
 
 # homepage
-homepage http://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/PortPlacement
+homepage https://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/PortPlacement
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
 # For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)

--- a/PortPlacement.s4ext
+++ b/PortPlacement.s4ext
@@ -38,7 +38,7 @@ status This extension is intended for public use and we expect to fully maintain
 description Assists in the planning of surgical port placement in a laparoscopic procedure.
 
 # Space separated list of urls
-screenshoturls http://www.slicer.org/slicerWiki/images/3/32/Portplacement.png
+screenshoturls https://www.slicer.org/slicerWiki/images/3/32/Portplacement.png
 
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 1

--- a/PortPlacement.s4ext
+++ b/PortPlacement.s4ext
@@ -28,7 +28,7 @@ contributors Andinet Enquobahrie (Kitware), Luis G. Torres (UNC), Jean-Christoph
 category IGT
 
 # url to icon (png, size 128x128 pixels)
-iconurl http://www.slicer.org/slicerWiki/images/a/a7/Portplacement_icon.png
+iconurl https://www.slicer.org/slicerWiki/images/a/a7/Portplacement_icon.png
 
 # Give people an idea what to expect from this code
 #  - Is it just a test or something you stand behind?

--- a/Q3DC.s4ext
+++ b/Q3DC.s4ext
@@ -18,7 +18,7 @@ depends SlicerMarkupConstraints
 build_subdirectory .
 
 # homepage
-homepage http://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/Q3DC
+homepage https://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/Q3DC
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
 # For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)

--- a/Q3DC.s4ext
+++ b/Q3DC.s4ext
@@ -38,7 +38,7 @@ status
 description This extension contains one module of the same name. Using placed fiducials, it allows users to compute 2D angles: Yaw, Pitch and Roll; and decompose the 3D distance into the three different components: R-L , A-P and S-I. It is possible to compute the middle point between two fiducials and export the values.
 
 # Space separated list of urls
-screenshoturls http://www.slicer.org/slicerWiki/index.php/File:Q3DC_Interface.png
+screenshoturls https://www.slicer.org/slicerWiki/index.php/File:Q3DC_Interface.png
 
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 1

--- a/RegistrationQA.s4ext
+++ b/RegistrationQA.s4ext
@@ -38,7 +38,7 @@ status Code has been developed in colaboration with GSI and UK Erlangen and shou
 description Image registration quality assurance tool.
 
 # Space separated list of urls
-screenshoturls http://wiki.slicer.org/slicerWiki/images/4/42/Slicer-r19441-LoadableExtensionTemplate-screenshot.png
+screenshoturls https://wiki.slicer.org/slicerWiki/images/4/42/Slicer-r19441-LoadableExtensionTemplate-screenshot.png
 
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 1

--- a/RegistrationQA.s4ext
+++ b/RegistrationQA.s4ext
@@ -28,7 +28,7 @@ contributors Kristjan Anderle (GSI), Tobias Brandt (University Clinic of Erlange
 category Registration
 
 # url to icon (png, size 128x128 pixels)
-iconurl https://github.com/gsi-biomotion/Slicer-RegQA/blob/master/RegQA/Resources/Icons/RegQAIcon.png
+iconurl https://raw.githubusercontent.com/gsi-biomotion/SlicerRegistrationQA/master/RegistrationQA/Resources/Icons/RegistrationQAIcon.png
 
 # Give people an idea what to expect from this code
 #  - Is it just a test or something you stand behind?

--- a/RegistrationQA.s4ext
+++ b/RegistrationQA.s4ext
@@ -38,7 +38,7 @@ status Code has been developed in colaboration with GSI and UK Erlangen and shou
 description Image registration quality assurance tool.
 
 # Space separated list of urls
-screenshoturls https://wiki.slicer.org/slicerWiki/images/4/42/Slicer-r19441-LoadableExtensionTemplate-screenshot.png
+screenshoturls https://raw.githubusercontent.com/gsi-biomotion/SlicerRegistrationQA/master/Screenshots/RegQAOverview.png
 
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 1

--- a/ResectionPlanner.s4ext
+++ b/ResectionPlanner.s4ext
@@ -4,7 +4,7 @@ contributors Matt Lougheed (Queen's University)
 depends NA
 description Modules for surgical resection planning.
 enabled 1
-homepage https://www.slicer.org/slicerWiki/index.php?title=Documentation/Nightly/Extensions/ResectionPlanner
+homepage https://www.slicer.org/wiki/Documentation/Nightly/Extensions/ResectionPlanner
 iconurl https://wiki.slicer.org/slicerWiki/images/d/d6/ResectionPlannerLogo.png
 scm git
 scmrevision master

--- a/ResectionPlanner.s4ext
+++ b/ResectionPlanner.s4ext
@@ -9,5 +9,5 @@ iconurl https://wiki.slicer.org/slicerWiki/images/d/d6/ResectionPlannerLogo.png
 scm git
 scmrevision master
 scmurl https://github.com/SlicerIGT/ResectionPlanner.git
-screenshoturls http://www.slicer.org/slicerWiki/index.php/File:ResectionVolume_Screenshot.png
+screenshoturls https://www.slicer.org/slicerWiki/index.php/File:ResectionVolume_Screenshot.png
 status

--- a/ResectionPlanner.s4ext
+++ b/ResectionPlanner.s4ext
@@ -4,7 +4,7 @@ contributors Matt Lougheed (Queen's University)
 depends NA
 description Modules for surgical resection planning.
 enabled 1
-homepage http://www.slicer.org/slicerWiki/index.php?title=Documentation/Nightly/Extensions/ResectionPlanner
+homepage https://www.slicer.org/slicerWiki/index.php?title=Documentation/Nightly/Extensions/ResectionPlanner
 iconurl http://wiki.slicer.org/slicerWiki/images/d/d6/ResectionPlannerLogo.png
 scm git
 scmrevision master

--- a/ResectionPlanner.s4ext
+++ b/ResectionPlanner.s4ext
@@ -5,7 +5,7 @@ depends NA
 description Modules for surgical resection planning.
 enabled 1
 homepage https://www.slicer.org/slicerWiki/index.php?title=Documentation/Nightly/Extensions/ResectionPlanner
-iconurl http://wiki.slicer.org/slicerWiki/images/d/d6/ResectionPlannerLogo.png
+iconurl https://wiki.slicer.org/slicerWiki/images/d/d6/ResectionPlannerLogo.png
 scm git
 scmrevision master
 scmurl https://github.com/SlicerIGT/ResectionPlanner.git

--- a/SNRMeasurement.s4ext
+++ b/SNRMeasurement.s4ext
@@ -38,7 +38,7 @@ status
 description 3D Slicer CLI to calculate SNR of images.
 
 # Space separated list of urls
-screenshoturls http://wiki.slicer.org/slicerWiki/images/a/ab/Slicer-r19441-SNRMeasurement-screenshot.png http://wiki.slicer.org/slicerWiki/images/1/1e/Slicer-r19441-SNRMeasurement-screenshot-2.png
+screenshoturls https://wiki.slicer.org/slicerWiki/images/a/ab/Slicer-r19441-SNRMeasurement-screenshot.png https://wiki.slicer.org/slicerWiki/images/1/1e/Slicer-r19441-SNRMeasurement-screenshot-2.png
 
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 1

--- a/SNRMeasurement.s4ext
+++ b/SNRMeasurement.s4ext
@@ -18,7 +18,7 @@ depends NA
 build_subdirectory .
 
 # homepage
-homepage https://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/SNRMeasurement
+homepage https://github.com/SNRLab/SNRMeasurement#snrmeasurement
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
 # For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)

--- a/SNRMeasurement.s4ext
+++ b/SNRMeasurement.s4ext
@@ -38,7 +38,7 @@ status
 description 3D Slicer CLI to calculate SNR of images.
 
 # Space separated list of urls
-screenshoturls https://wiki.slicer.org/slicerWiki/images/a/ab/Slicer-r19441-SNRMeasurement-screenshot.png https://wiki.slicer.org/slicerWiki/images/1/1e/Slicer-r19441-SNRMeasurement-screenshot-2.png
+screenshoturls https://raw.githubusercontent.com/SNRLab/SNRMeasurement/master/SNRRegions.png
 
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 1

--- a/SNRMeasurement.s4ext
+++ b/SNRMeasurement.s4ext
@@ -28,7 +28,7 @@ contributors Babak Matinfar (BWH), Junichi Tokuda (BWH)
 category IGT
 
 # url to icon (png, size 128x128 pixels)
-iconurl http://viewvc.slicer.org/viewvc.cgi/Slicer4/trunk/Extensions/Testing/SNRMeasurement/SNRMeasurement.png?revision=21745&view=co
+iconurl https://raw.githubusercontent.com/SNRLab/SNRMeasurement/master/SNRMeasurement.png
 
 # Give people an idea what to expect from this code
 #  - Is it just a test or something you stand behind?

--- a/SNRMeasurement.s4ext
+++ b/SNRMeasurement.s4ext
@@ -18,7 +18,7 @@ depends NA
 build_subdirectory .
 
 # homepage
-homepage http://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/SNRMeasurement
+homepage https://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/SNRMeasurement
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
 # For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)

--- a/SPHARM-PDM.s4ext
+++ b/SPHARM-PDM.s4ext
@@ -18,7 +18,7 @@ depends MeshToLabelMap
 build_subdirectory SPHARM-PDM-build
 
 # homepage
-homepage    http://www.nitrc.org/projects/spharm-pdm
+homepage    https://www.nitrc.org/projects/spharm-pdm
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
 # For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)

--- a/SPHARM-PDM.s4ext
+++ b/SPHARM-PDM.s4ext
@@ -28,7 +28,7 @@ contributors Beatriz Paniagua (UNC), Francois Budin (UNC), Martin Styner (UNC), 
 category SPHARM
 
 # url to icon (png, size 128x128 pixels)
-iconurl     http://www.na-mic.org/Wiki/images/a/ad/Spharm-pdm-icon.png
+iconurl     https://raw.githubusercontent.com/NIRALUser/SPHARM-PDM/master/Modules/Scripted/ShapeAnalysisModule/Resources/Icons/ShapeAnalysisModule.png
 
 # Give people an idea what to expect from this code
 #  - Is it just a test or something you stand beind?

--- a/SPHARM-PDM.s4ext
+++ b/SPHARM-PDM.s4ext
@@ -38,7 +38,7 @@ status
 description SPHARM-PDM is a tool that computes point-based models using a parametric boundary description for the computing of Shape Analysis.
 
 # Space separated list of urls
-screenshoturls http://www.na-mic.org/Wiki/images/3/34/Spharm-pdm-snapshot.png
+screenshoturls https://www.na-mic.org/w/img_auth.php/3/34/Spharm-pdm-snapshot.png
 
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 1

--- a/ScatteredTransform.s4ext
+++ b/ScatteredTransform.s4ext
@@ -18,7 +18,7 @@ depends NA
 build_subdirectory .
 
 # homepage
-homepage http://slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/ScatteredTransform
+homepage https://slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/ScatteredTransform
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
 # For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)

--- a/Scoliosis.s4ext
+++ b/Scoliosis.s4ext
@@ -28,7 +28,7 @@ contributors Franklin King (PerkLab, Queen's University), Tamas Ungi (PerkLab, Q
 category    Scoliosis
 
 # url to icon (png, size 128x128 pixels)
-iconurl     http://www.slicer.org/slicerWiki/images/2/2b/ScoliosisLogo.png
+iconurl     https://www.slicer.org/slicerWiki/images/2/2b/ScoliosisLogo.png
 
 # Give people an idea what to expect from this code
 #  - Is it just a test or something you stand beind?

--- a/Scoliosis.s4ext
+++ b/Scoliosis.s4ext
@@ -38,7 +38,7 @@ status      Experimental
 description Extensions pertaining to scoliosis analysis
 
 # Space separated list of urls
-screenshoturls http://www.slicer.org/slicerWiki/images/d/d1/ScoliosisScreenshot.png
+screenshoturls https://www.slicer.org/slicerWiki/images/d/d1/ScoliosisScreenshot.png
 
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 1

--- a/SegmentRegistration.s4ext
+++ b/SegmentRegistration.s4ext
@@ -38,7 +38,7 @@ status
 description Segment registration is an extension that contains generic and more specialized modules for registering two delineations of the same structure, and propagating other segmented structures from one dataset to the other (also called fusion or contour propagation).
 
 # Space separated list of urls
-screenshoturls https://www.slicer.org/w/images/a/a1/20170526_ProstatMRIUSContourPropagation.png https://www.slicer.org/w/images/1/15/20160329_MRIUS_1500.gif
+screenshoturls https://www.slicer.org/slicerWiki/images/a/a1/20170526_ProstatMRIUSContourPropagation.png https://www.slicer.org/slicerWiki/images/1/15/20160329_MRIUS_1500.gif
 
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 1

--- a/SegmentationAidedRegistration.s4ext
+++ b/SegmentationAidedRegistration.s4ext
@@ -28,7 +28,7 @@ contributors Yi Gao (BWH/UAB), Liang-Jia Zhu (UAB), Josh Cates (Utah), Alan Morr
 category Registration
 
 # url to icon (png, size 128x128 pixels)
-iconurl http://www.slicer.org/slicerWiki/images/b/ba/SegAidedRegSquareFocus128.png
+iconurl https://www.slicer.org/slicerWiki/images/b/ba/SegAidedRegSquareFocus128.png
 
 # Give people an idea what to expect from this code
 #  - Is it just a test or something you stand behind?

--- a/SegmentationAidedRegistration.s4ext
+++ b/SegmentationAidedRegistration.s4ext
@@ -18,7 +18,7 @@ depends NA
 build_subdirectory .
 
 # homepage
-homepage http://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Modules/SegmentationAidedRegistration
+homepage https://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Modules/SegmentationAidedRegistration
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
 # For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)

--- a/SegmentationAidedRegistration.s4ext
+++ b/SegmentationAidedRegistration.s4ext
@@ -38,7 +38,7 @@ status
 description Performe the registration with the aid from segmentation so that the segmented regions have close match.
 
 # Space separated list of urls
-screenshoturls http://www.slicer.org/slicerWiki/images/b/ba/SegmentationAidedRegistrationUsageScreenShot.png
+screenshoturls https://www.slicer.org/slicerWiki/images/b/ba/SegmentationAidedRegistrationUsageScreenShot.png
 
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 1

--- a/ShapePopulationViewer.s4ext
+++ b/ShapePopulationViewer.s4ext
@@ -38,7 +38,7 @@ status
 description Visualize and interact with multiple surfaces at the same time to easily compare them
 
 # Space separated list of urls
-screenshoturls http://wiki.na-mic.org/Wiki/images/8/81/Screenshot1.png http://wiki.na-mic.org/Wiki/images/1/13/SPVscreenshot2.png
+screenshoturls https://www.na-mic.org/w/img_auth.php/8/81/Screenshot1.png https://www.na-mic.org/w/img_auth.php/1/13/SPVscreenshot2.png
 
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 1

--- a/ShapeVariationAnalyzer.s4ext
+++ b/ShapeVariationAnalyzer.s4ext
@@ -28,7 +28,7 @@ contributors Priscille de Dumast (University of Michigan), Laura Pascal (Univers
 category Quantification
 
 # url to icon (png, size 128x128 pixels)
-iconurl https://www.slicer.org/w/images/3/30/ShapeVariationAnalyzer-Logo.png
+iconurl https://www.slicer.org/slicerWiki/images/3/30/ShapeVariationAnalyzer-Logo.png
 
 # Give people an idea what to expect from this code
 #  - Is it just a test or something you stand behind?
@@ -38,7 +38,7 @@ status
 description ShapeVariationAnalyzer allows the classification of 3D models, according to their morphological variations. This tool is based on a deep learning neural network.
 
 # Space separated list of urls
-screenshoturls https://www.slicer.org/w/images/f/f0/FullView_ShapeVariationAnalyzer.png https://www.slicer.org/w/images/5/57/ShapeVariationAnalyzer-GUI.png https://www.slicer.org/w/images/3/30/ShapeVariationAnalyzer-Logo.png
+screenshoturls https://www.slicer.org/slicerWiki/images/f/f0/FullView_ShapeVariationAnalyzer.png https://www.slicer.org/slicerWiki/images/5/57/ShapeVariationAnalyzer-GUI.png https://www.slicer.org/slicerWiki/images/3/30/ShapeVariationAnalyzer-Logo.png
 
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 1

--- a/ShapeVariationAnalyzer.s4ext
+++ b/ShapeVariationAnalyzer.s4ext
@@ -18,7 +18,7 @@ depends ShapePopulationViewer
 build_subdirectory inner-build
 
 # homepage
-homepage http://slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/ShapeVariationAnalyzer
+homepage https://slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/ShapeVariationAnalyzer
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
 # For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)

--- a/SkinMouldGenerator.s4ext
+++ b/SkinMouldGenerator.s4ext
@@ -18,7 +18,7 @@ depends NA
 build_subdirectory .
 
 # homepage
-homepage https://www.slicer.org/wiki/Documentation/Nightly/Extensions/SkinMouldGenerator
+homepage https://github.com/PerkLab/SlicerSkinMouldGenerator#readme
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
 # For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)

--- a/SkullStripper.s4ext
+++ b/SkullStripper.s4ext
@@ -28,7 +28,7 @@ contributors Xiaodong Tao (GE), Jean-Christophe Fillion-Robin (Kitware)
 category Segmentation
 
 # url to icon (png, size 128x128 pixels)
-iconurl http://www.slicer.org/slicerWiki/images/f/f2/SkullStripper.png
+iconurl https://www.slicer.org/slicerWiki/images/f/f2/SkullStripper.png
 
 # Give people an idea what to expect from this code
 #  - Is it just a test or something you stand behind?

--- a/SkullStripper.s4ext
+++ b/SkullStripper.s4ext
@@ -18,7 +18,7 @@ depends NA
 build_subdirectory .
 
 # homepage
-homepage http://www.slicer.org/slicerWiki/index.php/Documentation/4.1/Modules/SkullStripper
+homepage https://www.slicer.org/slicerWiki/index.php/Documentation/4.1/Modules/SkullStripper
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
 # For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)

--- a/SkullStripper.s4ext
+++ b/SkullStripper.s4ext
@@ -38,7 +38,7 @@ status
 description Skull stripping for structural MR images of the brain, tested on T1 and T2 contrast.
 
 # Space separated list of urls
-screenshoturls http://wiki.slicer.org/slicerWiki/images/a/ab/Slicer-r19441-CLIExtensionTemplate-screenshot.png http://wiki.slicer.org/slicerWiki/images/1/1e/Slicer-r19441-CLIExtensionTemplate-screenshot-2.png
+screenshoturls https://wiki.slicer.org/slicerWiki/images/a/ab/Slicer-r19441-CLIExtensionTemplate-screenshot.png https://wiki.slicer.org/slicerWiki/images/1/1e/Slicer-r19441-CLIExtensionTemplate-screenshot-2.png
 
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 1

--- a/SlicerCochlea.s4ext
+++ b/SlicerCochlea.s4ext
@@ -40,7 +40,7 @@ Ibraheem Al-Dhamari, Sabine Bauer, Dietrich Paulus and Roland Jacob, (2017): Aut
 Ibraheem Al-Dhamari, Sabine Bauer, Dietrich Paulus, Friedrich Lisseck and Roland Jacob, (2017): ACIR: automatic cochlea image registration. In: Proceedings SPIE Medical Imaging 2017: Image Processing
 
 # Space separated list of urls
-screenshoturls https://raw.githubusercontent.com/MedicalImageAnalysisTutorials/SlicerCochlea/master/Screenshots/c.png https://raw.githubusercontent.com/MedicalImageAnalysisTutorials/SlicerCochlea/master/Screenshots/r1.png  https://raw.githubusercontent.com/MedicalImageAnalysisTutorials/SlicerCochlea/master/Screenshots/r2.png https://raw.githubusercontent.com/MedicalImageAnalysisTutorials/SlicerCochlea/master/Screenshots/s1.png https://raw.githubusercontent.com/MedicalImageAnalysisTutorials/SlicerCochlea/master/Screenshots/s2.png
+screenshoturls https://raw.githubusercontent.com/MedicalImageAnalysisTutorials/SlicerCochlea/master/Screenshots/c.png https://raw.githubusercontent.com/MedicalImageAnalysisTutorials/SlicerCochlea/master/Screenshots/r1.png https://raw.githubusercontent.com/MedicalImageAnalysisTutorials/SlicerCochlea/master/Screenshots/r2.png https://raw.githubusercontent.com/MedicalImageAnalysisTutorials/SlicerCochlea/master/Screenshots/s1.png https://raw.githubusercontent.com/MedicalImageAnalysisTutorials/SlicerCochlea/master/Screenshots/s2.png
 
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 1

--- a/SlicerConda.s4ext
+++ b/SlicerConda.s4ext
@@ -18,7 +18,7 @@ depends NA
 build_subdirectory .
 
 # homepage
-https://github.com/DCBIA-OrthoLab/SlicerConda/blob/main/README.md
+homepage https://github.com/DCBIA-OrthoLab/SlicerConda#readme
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
 # For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)

--- a/SlicerDcm2nii.s4ext
+++ b/SlicerDcm2nii.s4ext
@@ -18,7 +18,7 @@ depends NA
 build_subdirectory inner-build
 
 # homepage
-homepage http://slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/SlicerDcm2nii
+homepage https://slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/SlicerDcm2nii
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
 # For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)

--- a/SlicerDensityLungSegmentation.s4ext
+++ b/SlicerDensityLungSegmentation.s4ext
@@ -33,7 +33,7 @@ iconurl    https://raw.githubusercontent.com/pzaffino/SlicerDensityLungSegmentat
 status      alpha
 
 # One line stating what the module does
-This extension labels lung tissues on basis of density (air, healthy, ground-glass opacities, consolidation, and denser tissues). Voxel-per-voxel label is provided alongside with an averaged volume.
+description This extension labels lung tissues on basis of density (air, healthy, ground-glass opacities, consolidation, and denser tissues). Voxel-per-voxel label is provided alongside with an averaged volume.
 
 # Space separated list of urls
 screenshoturls https://raw.githubusercontent.com/pzaffino/SlicerDensityLungSegmentation/main/DensityLungSegmentation_screenshot.png

--- a/SlicerDevelopmentToolbox.s4ext
+++ b/SlicerDevelopmentToolbox.s4ext
@@ -28,7 +28,7 @@ contributors Christian Herz (Brigham and Women's Hospital), Andrey Fedorov (Brig
 category    Informatics
 
 # url to icon (png, size 128x128 pixels)
-iconurl http://raw.githubusercontent.com/QIICR/SlicerDevelopmentToolbox/master/Resources/Icons/SlicerDevelopmentToolbox.png
+iconurl https://raw.githubusercontent.com/QIICR/SlicerDevelopmentToolbox/master/Resources/Icons/SlicerDevelopmentToolbox.png
 
 # Give people an idea what to expect from this code
 #  - Is it just a test or something you stand behind?

--- a/SlicerDevelopmentToolbox.s4ext
+++ b/SlicerDevelopmentToolbox.s4ext
@@ -38,7 +38,7 @@ status      Work in progress
 description SlicerDevelopmentToolbox extension facilitates the development process of modules/extensions with a large variety of widgets, helpers, decorators, events, constants and mixin classes
 
 # Space separated list of urls
-screenshoturls http://www.slicer.org/wiki/File:IncomingDataWindow.png http://www.slicer.org/wiki/File:ModuleSettingsWidget.png http://www.slicer.org/wiki/File:RatingWindow.png http://www.slicer.org/wiki/File:TargetCreationWidget.png http://www.slicer.org/wiki/File:Watchbox.png
+screenshoturls https://www.slicer.org/slicerWiki/images/0/0b/IncomingDataWindow.png https://www.slicer.org/slicerWiki/images/2/22/ModuleSettingsWidget.png https://www.slicer.org/slicerWiki/images/c/c9/RatingWindow.png https://www.slicer.org/slicerWiki/images/2/2a/TargetCreationWidget.png https://www.slicer.org/slicerWiki/images/e/ea/Watchbox.png
 
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 1

--- a/SlicerFab.s4ext
+++ b/SlicerFab.s4ext
@@ -18,7 +18,7 @@ depends NA
 build_subdirectory .
 
 # homepage
-homepage http://github.com/SlicerFab/SlicerFab
+homepage https://github.com/SlicerFab/SlicerFab
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
 # For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)

--- a/SlicerHeart.s4ext
+++ b/SlicerHeart.s4ext
@@ -18,7 +18,7 @@ depends     SlicerIGT
 build_subdirectory inner-build
 
 # homepage
-homepage    http://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/SlicerHeart
+homepage    https://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/SlicerHeart
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
 # For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)

--- a/SlicerIGT.s4ext
+++ b/SlicerIGT.s4ext
@@ -28,7 +28,7 @@ contributors Tamas Ungi (Queen's University), Junichi Tokuda (Brigham and Women'
 category    IGT
 
 # url to icon (png, size 128x128 pixels)
-iconurl     http://www.slicer.org/slicerWiki/images/2/2b/SlicerIGTLogo.png
+iconurl     https://www.slicer.org/slicerWiki/images/2/2b/SlicerIGTLogo.png
 
 # Give people an idea what to expect from this code
 #  - Is it just a test or something you stand behind?

--- a/SlicerIGT.s4ext
+++ b/SlicerIGT.s4ext
@@ -18,7 +18,7 @@ depends SlicerIGSIO
 build_subdirectory .
 
 # homepage
-homepage    http://www.slicerigt.org
+homepage    https://www.slicerigt.org
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
 # For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)

--- a/SlicerIGT.s4ext
+++ b/SlicerIGT.s4ext
@@ -38,7 +38,7 @@ status
 description This extension contains modules that enable rapid prototyping of applications for image-guided interventions. Intended users should have real-time imaging and/or tracking hardware (e.g. tracked ultrasound) connected to 3D Slicer through OpenIGTLink network. Specific modules allow patient registration to the navigation coordinate system in 3D Slicer, and real-time update of tracked models and images.
 
 # Space separated list of urls
-screenshoturls http://www.slicer.org/slicerWiki/images/7/78/SlicerIGTScreenshot.png
+screenshoturls https://www.slicer.org/slicerWiki/images/7/78/SlicerIGTScreenshot.png
 
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 1

--- a/SlicerOpenAnatomy.s4ext
+++ b/SlicerOpenAnatomy.s4ext
@@ -38,7 +38,7 @@ status
 description 3D Slicer extension for exporting Slicer scenes to use in the OpenAnatomy.org browser
 
 # Space separated list of urls
-screenshoturls https://raw.githubusercontent.com/PerkLab/SlicerOpenAnatomy/master/Screenshot01.png
+screenshoturls https://raw.githubusercontent.com/PerkLab/SlicerOpenAnatomy/master/OpenAnatomyExport/img/Screenshot01.png https://raw.githubusercontent.com/PerkLab/SlicerOpenAnatomy/master/OpenAnatomyExport/img/Screenshot02.png https://raw.githubusercontent.com/PerkLab/SlicerOpenAnatomy/master/OpenAnatomyExport/img/Screenshot03.png
 
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 1

--- a/SlicerOpenCV.s4ext
+++ b/SlicerOpenCV.s4ext
@@ -18,7 +18,7 @@ depends     NA
 build_subdirectory inner-build
 
 # homepage
-homepage    http://slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/SlicerOpenCV
+homepage    https://slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/SlicerOpenCV
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
 # For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)

--- a/SlicerProstate.s4ext
+++ b/SlicerProstate.s4ext
@@ -28,7 +28,7 @@ contributors Andrey Fedorov (Brigham and Women's Hospital), Andras Lasso (Queen'
 category    Informatics
 
 # url to icon (png, size 128x128 pixels)
-iconurl     http://wiki.slicer.org/slicerWiki/images/8/87/SlicerProstate_Logo_1.0_128x128.png
+iconurl     https://wiki.slicer.org/slicerWiki/images/8/87/SlicerProstate_Logo_1.0_128x128.png
 
 # Give people an idea what to expect from this code
 #  - Is it just a test or something you stand behind?

--- a/SlicerProstate.s4ext
+++ b/SlicerProstate.s4ext
@@ -38,7 +38,7 @@ status      Work in progress
 description SlicerProstate extension hosts various modules to facilitate processing and management of prostate image data, utilizing prostate images in image-guided interventions and development of the imaging biomarkers of the prostate cancer.
 
 # Space separated list of urls
-screenshoturls http://wiki.slicer.org/slicerWiki/images/f/ff/DistanceMapBasedRegistration_example1.png http://wiki.slicer.org/slicerWiki/images/3/36/SegmentationSmoothing_example1.png http://wiki.slicer.org/slicerWiki/images/c/c3/QuadEdgeSurfaceMesher_example1.png
+screenshoturls https://wiki.slicer.org/slicerWiki/images/f/ff/DistanceMapBasedRegistration_example1.png https://wiki.slicer.org/slicerWiki/images/3/36/SegmentationSmoothing_example1.png https://wiki.slicer.org/slicerWiki/images/c/c3/QuadEdgeSurfaceMesher_example1.png
 
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 1

--- a/SlicerProstate.s4ext
+++ b/SlicerProstate.s4ext
@@ -18,7 +18,7 @@ depends     NA
 build_subdirectory .
 
 # homepage
-homepage http://wiki.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/SlicerProstate
+homepage https://wiki.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/SlicerProstate
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
 # For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)

--- a/SlicerRT.s4ext
+++ b/SlicerRT.s4ext
@@ -28,7 +28,7 @@ contributors Csaba Pinter (PerkLab, Queen's University), Andras Lasso (PerkLab, 
 category Radiotherapy
 
 # url to icon (png, size 128x128 pixels)
-iconurl http://www.slicer.org/slicerWiki/images/2/29/SlicerRT_Logo_3.0_128x128.png
+iconurl https://www.slicer.org/slicerWiki/images/2/29/SlicerRT_Logo_3.0_128x128.png
 
 # Give people an idea what to expect from this code
 #  - Is it just a test or something you stand behind?

--- a/SlicerRT.s4ext
+++ b/SlicerRT.s4ext
@@ -18,7 +18,7 @@ depends NA
 build_subdirectory inner-build
 
 # homepage
-homepage http://slicerrt.org
+homepage https://slicerrt.org
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
 # For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)

--- a/SlicerRT.s4ext
+++ b/SlicerRT.s4ext
@@ -38,7 +38,7 @@ status Release
 description Toolkit for radiation therapy research. Features include DICOM-RT import/export, dose volume histogram, dose accumulation, external beam planning (TPS), structure comparison and morphology, isodose line/surface generation, etc. Version 0.18.0
 
 # Space separated list of urls
-screenshoturls http://www.slicer.org/slicerWiki/images/8/87/SlicerRT_0.10_IsocenterShiftingEvaluation.png http://www.slicer.org/slicerWiki/images/e/ef/SlicerRT_0.11_ProstateLoaded_Beams_ThresholdedDose.png http://www.slicer.org/slicerWiki/images/4/40/SlicerRtFundingSources.png
+screenshoturls https://www.slicer.org/slicerWiki/images/8/87/SlicerRT_0.10_IsocenterShiftingEvaluation.png https://www.slicer.org/slicerWiki/images/e/ef/SlicerRT_0.11_ProstateLoaded_Beams_ThresholdedDose.png https://www.slicer.org/slicerWiki/images/4/40/SlicerRtFundingSources.png
 
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 1

--- a/SlicerRadiomics.s4ext
+++ b/SlicerRadiomics.s4ext
@@ -38,7 +38,7 @@ status beta
 description Radiomics extension provides a 3D Slicer interface to the pyradiomics library. pyradiomics is an open-source python package for the extraction of Radiomics features from medical imaging.
 
 # Space separated list of urls
-screenshoturls http://www.slicer.org/w/images/3/3b/SlicerRadiomics-lung.png
+screenshoturls https://www.slicer.org/slicerWiki/images/3/3b/SlicerRadiomics-lung.png
 
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 1

--- a/SlicerRegularizedFastMarching.s4ext
+++ b/SlicerRegularizedFastMarching.s4ext
@@ -18,7 +18,7 @@ depends NA
 build_subdirectory .
 
 # homepage
-homepage https://github.com/AldrickF/SlicerRegularizedFastMarching
+homepage https://github.com/jamesobutler/SlicerRegularizedFastMarching#readme
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
 # For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)
@@ -28,7 +28,7 @@ contributors Aldrick FAURE, Sandra LEBRETON, Laurent RISSER (CNRS, Toulouse Math
 category Segmentation
 
 # url to icon (png, size 128x128 pixels)
-iconurl https://github.com/AldrickF/SlicerRegularizedFastMarching/blob/main/Resources/Icons/RegularizedFastMarching.png
+iconurl https://raw.githubusercontent.com/jamesobutler/SlicerRegularizedFastMarching/main/RegularizedFastMarching/Resources/Icons/RegularizedFastMarching.png
 
 # Give people an idea what to expect from this code
 #  - Is it just a test or something you stand behind?
@@ -38,7 +38,7 @@ status Tested on various images ; should work well
 description This module allows the semi-automatic segmentation of 3D medical images using regularized fast marching.
 
 # Space separated list of urls
-screenshoturls https://github.com/AldrickF/SlicerRegularizedFastMarching/blob/main/Resources/Icons/SlicerRFM_README_Fig3.png
+screenshoturls https://raw.githubusercontent.com/jamesobutler/SlicerRegularizedFastMarching/main/Docs/SlicerRFM_README_Fig3.png https://raw.githubusercontent.com/jamesobutler/SlicerRegularizedFastMarching/main/Docs/SlicerRFM_README_Fig2.png https://raw.githubusercontent.com/jamesobutler/SlicerRegularizedFastMarching/main/Docs/SlicerRFM_README_Fig4.png
 
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 1

--- a/SlicerToKiwiExporter.s4ext
+++ b/SlicerToKiwiExporter.s4ext
@@ -18,7 +18,7 @@ depends     NA
 build_subdirectory .
 
 # homepage
-homepage    http://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/SlicerToKiwiExporter
+homepage    https://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/SlicerToKiwiExporter
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
 # For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)

--- a/SlicerToKiwiExporter.s4ext
+++ b/SlicerToKiwiExporter.s4ext
@@ -38,7 +38,7 @@ status
 description The SlicerToKiwiExporter module provides Slicer user with any easy way to export models into a KiwiViewer scene file.
 
 # Space separated list of urls
-screenshoturls http://www.slicer.org/slicerWiki/images/9/9e/SlicerToKiwiExporter_Kiwiviewer_8.PNG http://www.slicer.org/slicerWiki/images/a/ab/SlicerToKiwiExporter_Kiwiviewer_9.PNG http://www.slicer.org/slicerWiki/images/9/9a/SlicerToKiwiExporter_SaveDialog_Select-file-format_1.png
+screenshoturls https://www.slicer.org/slicerWiki/images/9/9e/SlicerToKiwiExporter_Kiwiviewer_8.PNG https://www.slicer.org/slicerWiki/images/a/ab/SlicerToKiwiExporter_Kiwiviewer_9.PNG https://www.slicer.org/slicerWiki/images/9/9a/SlicerToKiwiExporter_SaveDialog_Select-file-format_1.png
 
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 1

--- a/SlicerVMTK.s4ext
+++ b/SlicerVMTK.s4ext
@@ -38,7 +38,7 @@ status Beta
 description Vascular Modeling Toolkit for vessel tree segmentation and centerline extraction.
 
 # Space separated list of urls
-screenshoturls http://www.nitrc.org/project/screenshot.php?group_id=196&screenshot_id=126 http://www.nitrc.org/project/screenshot.php?group_id=196&screenshot_id=227 http://www.nitrc.org/project/screenshot.php?group_id=196&screenshot_id=228 http://www.nitrc.org/project/screenshot.php?group_id=196&screenshot_id=229
+screenshoturls https://www.nitrc.org/project/screenshot.php?group_id=196&screenshot_id=126 https://www.nitrc.org/project/screenshot.php?group_id=196&screenshot_id=227 https://www.nitrc.org/project/screenshot.php?group_id=196&screenshot_id=228 https://www.nitrc.org/project/screenshot.php?group_id=196&screenshot_id=229
 
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 1

--- a/SlicerVMTK.s4ext
+++ b/SlicerVMTK.s4ext
@@ -28,7 +28,7 @@ contributors Daniel Haehn (Boston Childrens Hospital), Luca Antiga (Orobix), Ste
 category Vascular Modeling Toolkit
 
 # url to icon (png, size 128x128 pixels)
-iconurl http://www.nitrc.org/project/screenshot.php?group_id=196&screenshot_id=269
+iconurl https://www.nitrc.org/project/screenshot.php?group_id=196&screenshot_id=269
 
 # Give people an idea what to expect from this code
 #  - Is it just a test or something you stand behind?

--- a/SlicerVirtualReality.s4ext
+++ b/SlicerVirtualReality.s4ext
@@ -38,7 +38,7 @@ status
 description Allows user to interact with a Slicer scene using virtual reality.
 
 # Space separated list of urls
-screenshoturls https://www.slicer.org/w/images/4/49/SlicerVirtualReality_Screenshot1.png https://www.slicer.org/w/images/0/04/SlicerVirtualReality_Screenshot2.png
+screenshoturls https://www.slicer.org/slicerWiki/images/4/49/SlicerVirtualReality_Screenshot1.png https://www.slicer.org/slicerWiki/images/0/04/SlicerVirtualReality_Screenshot2.png
 
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 1

--- a/SlicerWMA.s4ext
+++ b/SlicerWMA.s4ext
@@ -20,6 +20,7 @@ status WIP
 description SlicerWMA currently provides the WhiteMatterAnalysis (https://github.com/SlicerDMRI/whitematteranalysis) python package and dependencies installed within Slicer's Python environment.
 
 # Space separated list of urls
+screenshoturls
 
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 0

--- a/SoundControl.s4ext
+++ b/SoundControl.s4ext
@@ -38,7 +38,7 @@ status
 description Navigate using sound feedback
 
 # Space separated list of urls
-screenshoturls   https://github.com/SlicerIGT/SlicerSoundControl/raw/master/OpenSoundControl.png   https://github.com/SlicerIGT/SlicerSoundControl/raw/master/SoundNavigation.png   https://github.com/SlicerIGT/SlicerSoundControl/raw/master/PureData.png
+screenshoturls   https://github.com/SlicerIGT/SlicerSoundControl/raw/master/OpenSoundControl.png https://github.com/SlicerIGT/SlicerSoundControl/raw/master/SoundNavigation.png https://github.com/SlicerIGT/SlicerSoundControl/raw/master/PureData.png
 
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 1

--- a/SurfaceFragmentsRegistration.s4ext
+++ b/SurfaceFragmentsRegistration.s4ext
@@ -33,7 +33,7 @@ iconurl https://github.com/sebastianandress/Slicer-SurfaceFragmentsRegistration/
 status Beta
 
 # One line stating what the module does
-A polydata/model registration and validation method that finds multiple high accuracy similarity zones on a source model deviating less than a definable threshold from a target model.
+description A polydata/model registration and validation method that finds multiple high accuracy similarity zones on a source model deviating less than a definable threshold from a target model.
 
 # Space separated list of urls
 screenshoturls https://github.com/sebastianandress/Slicer-SurfaceFragmentsRegistration/raw/master/Resources/screenshot1.png

--- a/SurfaceWrapSolidify.s4ext
+++ b/SurfaceWrapSolidify.s4ext
@@ -38,7 +38,7 @@ status Beta
 description A Segment Editor Extension that filters the surface of a segment using a combination of shrinkwrapping and raycasting.
 
 # Space separated list of urls
-screenshoturls https://github.com/sebastianandress/Slicer-SurfaceWrapSolidify/raw/master/Resources/Screenshots/screenshot1.png
+screenshoturls https://raw.githubusercontent.com/sebastianandress/Slicer-SurfaceWrapSolidify/master/Resources/Screenshots/screenshot4.png
 
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 1

--- a/T1Mapping.s4ext
+++ b/T1Mapping.s4ext
@@ -18,7 +18,7 @@ depends     NA
 build_subdirectory .
 
 # homepage
-homepage    http://slicer.org/slicerWiki/index.php/Documentation/Nightly/Modules/T1Mapping
+homepage    https://slicer.org/slicerWiki/index.php/Documentation/Nightly/Modules/T1Mapping
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
 # For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)

--- a/T1Mapping.s4ext
+++ b/T1Mapping.s4ext
@@ -28,7 +28,7 @@ contributors Xiao Da(MGH)
 category    Quantification
 
 # url to icon (png, size 128x128 pixels)
-iconurl     http://slicer.org/slicerWiki/images/3/32/T1_Mapping_Logo_Resized.png
+iconurl     https://slicer.org/slicerWiki/images/3/32/T1_Mapping_Logo_Resized.png
 
 # Give people an idea what to expect from this code
 #  - Is it just a test or something you stand behind?

--- a/T1Mapping.s4ext
+++ b/T1Mapping.s4ext
@@ -38,7 +38,7 @@ status
 description T1 mapping estimates effective tissue parameter maps (T1) from multi-spectral FLASH MRI scans with different flip angles.
 
 # Space separated list of urls
-screenshoturls http://slicer.org/slicerWiki/images/6/68/T1_Mapping_CPP_GUI.png
+screenshoturls https://slicer.org/slicerWiki/images/6/68/T1_Mapping_CPP_GUI.png
 
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 1

--- a/T2mapping.s4ext
+++ b/T2mapping.s4ext
@@ -18,7 +18,7 @@ depends     NA
 build_subdirectory .
 
 # homepage
-homepage    N/a
+homepage    https://github.com/gattia/Slicer-T2mapping#readme
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
 # For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)
@@ -38,6 +38,7 @@ status      Calculations work. Im sure improvements to Slicer related code could
 description T2mapping creates a T2 Map from an inputed 4D multi-echo MRI.
 
 # Space separated list of urls
+screenshoturls https://raw.githubusercontent.com/gattia/Slicer-T2mapping/master/Screenshots/1_Module_and_multi_echo_t2_image.png https://raw.githubusercontent.com/gattia/Slicer-T2mapping/master/Screenshots/2_Module_create_new_volume_t2.png https://raw.githubusercontent.com/gattia/Slicer-T2mapping/master/Screenshots/3_Example_resulting_t2_map_r2_threshold_0.7_t2_upper_threshold_100.png https://raw.githubusercontent.com/gattia/Slicer-T2mapping/master/Screenshots/4_Example_resulting_R2_map_r2_threshold_0.7_t2_upper_threshold_100.png
 
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 1

--- a/UKFTractography.s4ext
+++ b/UKFTractography.s4ext
@@ -19,7 +19,7 @@ depends     NA
 build_subdirectory .
 
 # homepage
-homepage  http://www.nitrc.org/projects/ukftractography/
+homepage  https://www.nitrc.org/projects/ukftractography/
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
 # For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)

--- a/UKFTractography.s4ext
+++ b/UKFTractography.s4ext
@@ -39,7 +39,7 @@ status      Alpha
 description A framework which uses an unscented Kalman filter for performing tractography. The development of this module was supported by NIH grants R01 MH097979 (PI Rathi), R01 MH092862 (PIs Westin and Verma), U01 NS083223 (PI Westin), R01 MH074794 (PI Westin) and P41 EB015902 (PI Kikinis).
 
 # Space separated list of urls
-# screenshoturls http://wiki.slicer.org/slicerWiki/images/a/ab/Slicer-r19441-CLIExtensionTemplate-screenshot.png http://wiki.slicer.org/slicerWiki/images/1/1e/Slicer-r19441-CLIExtensionTemplate-screenshot-2.png
+screenshoturls
 
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 1

--- a/VolumeClip.s4ext
+++ b/VolumeClip.s4ext
@@ -38,7 +38,7 @@ status
 description Clip volumes with surface models and ROI boxes
 
 # Space separated list of urls
-screenshoturls http://www.slicer.org/slicerWiki/images/4/4c/VolumeClipScreenshot1.png http://www.slicer.org/slicerWiki/images/5/57/VolumeClipScreenshot2.png http://www.slicer.org/slicerWiki/images/1/1a/VolumeClipScreenshot3.png
+screenshoturls https://www.slicer.org/slicerWiki/images/4/4c/VolumeClipScreenshot1.png https://www.slicer.org/slicerWiki/images/5/57/VolumeClipScreenshot2.png https://www.slicer.org/slicerWiki/images/1/1a/VolumeClipScreenshot3.png
 
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 1

--- a/VolumeClip.s4ext
+++ b/VolumeClip.s4ext
@@ -28,7 +28,7 @@ contributors Andras Lasso, Matt Lougheed (PerkLab, Queen's University)
 category    Segmentation
 
 # url to icon (png, size 128x128 pixels)
-iconurl     http://www.slicer.org/slicerWiki/images/c/c2/VolumeClipLogo.png
+iconurl     https://www.slicer.org/slicerWiki/images/c/c2/VolumeClipLogo.png
 
 # Give people an idea what to expect from this code
 #  - Is it just a test or something you stand behind?

--- a/VolumeClip.s4ext
+++ b/VolumeClip.s4ext
@@ -18,7 +18,7 @@ depends     NA
 build_subdirectory .
 
 # homepage
-homepage    http://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/VolumeClip
+homepage    https://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/VolumeClip
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
 # For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)

--- a/XNATSlicer.s4ext
+++ b/XNATSlicer.s4ext
@@ -18,7 +18,7 @@ depends     NA
 build_subdirectory .
 
 # homepage
-homepage    http://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/XNATSlicer
+homepage    https://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/XNATSlicer
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
 # For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)

--- a/ZFrameRegistration.s4ext
+++ b/ZFrameRegistration.s4ext
@@ -18,7 +18,7 @@ depends SlicerDevelopmentToolbox
 build_subdirectory .
 
 # homepage
-homepage http://slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/ZFrameRegistration
+homepage https://slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/ZFrameRegistration
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
 # For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)

--- a/ZFrameRegistration.s4ext
+++ b/ZFrameRegistration.s4ext
@@ -18,7 +18,7 @@ depends SlicerDevelopmentToolbox
 build_subdirectory .
 
 # homepage
-homepage https://slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/ZFrameRegistration
+homepage https://github.com/SlicerProstate/SlicerZFrameRegistration
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
 # For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)

--- a/iGyne.s4ext
+++ b/iGyne.s4ext
@@ -9,5 +9,5 @@ iconurl https://raw.github.com/gpernelle/iGyne/master/iGyne.png
 scm git
 scmrevision a57c534d11db46e6b1985c6caf6827bbcbae880e
 scmurl https://github.com/gpernelle/iGyne.git
-screenshoturls https://raw.github.com/gpernelle/iGyne/master/LabelingResult.png
+screenshoturls https://raw.githubusercontent.com/gpernelle/iGyne/master/LabelingResults.png
 status

--- a/mpReview.s4ext
+++ b/mpReview.s4ext
@@ -38,7 +38,7 @@ status      Work in progress
 description mpReview extension facilitates review and annotation (segmentation) of multi-parametric imaging datasets.
 
 # Space separated list of urls
-screenshoturls  https://github.com/SlicerProstate/mpReview/Resources/Icons/mpReview-screenshot.png
+screenshoturls  https://raw.githubusercontent.com/SlicerProstate/mpReview/master/Resources/Icons/mpReview_screenshot.PNG
 
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 1

--- a/scripts/check_description_files.py
+++ b/scripts/check_description_files.py
@@ -211,7 +211,7 @@ def main():
             check_screenshoturls,
         ]
 
-    total_failure_count = 0
+    extension_failures = {}
 
     file_paths = getattr(args, "/path/to/description.s4ext")
     for file_path in file_paths:
@@ -226,6 +226,12 @@ def main():
             except ExtensionCheckError as exc:
                 failures.append(str(exc))
 
+        # Keep track extension errors removing duplicates
+        extension_failures[extension_name] = list(set(failures))
+
+    total_failure_count = 0
+
+    for extension_name, failures in extension_failures.items():
         if failures:
             total_failure_count += len(failures)
             print("%s.s4ext" % extension_name)

--- a/scripts/check_description_files.py
+++ b/scripts/check_description_files.py
@@ -86,8 +86,8 @@ def check_homepage(extension_name, metadata):
 def check_iconurl(extension_name, metadata):
     check_name = "check_iconurl"
     iconurl = metadata["iconurl"]
-    if not iconurl.startswith("http"):
-        msg = f"iconurl is '{iconurl}' but it does not start with http"
+    if not iconurl.startswith("https://"):
+        msg = f"iconurl is '{iconurl}' but it does not start with https"
         raise ExtensionCheckError(extension_name, check_name, msg)
 
 

--- a/scripts/check_description_files.py
+++ b/scripts/check_description_files.py
@@ -49,7 +49,7 @@ def check_url(url, timeout=1):
     @retry(TimeoutError, tries=3, delay=1, jitter=1, max_delay=3)
     def _check_url():
         opener = urllib.request.build_opener()
-        opener.addheaders = [("User-agent", "Mozilla/5.0")]
+        opener.addheaders = [("User-agent", "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:124.0) Gecko/20100101 Firefox/124.0")]
         return opener.open(url, timeout=timeout).getcode(), None
     try:
         return _check_url()

--- a/scripts/check_description_files.py
+++ b/scripts/check_description_files.py
@@ -211,10 +211,7 @@ def main():
             check_screenshoturls,
         ]
 
-    extension_failures = {}
-
-    file_paths = getattr(args, "/path/to/description.s4ext")
-    for file_path in file_paths:
+    def _check_extension(file_path):
         extension_name = os.path.splitext(os.path.basename(file_path))[0]
 
         failures = []
@@ -227,7 +224,13 @@ def main():
                 failures.append(str(exc))
 
         # Keep track extension errors removing duplicates
-        extension_failures[extension_name] = list(set(failures))
+        return extension_name, list(set(failures))
+
+    extension_failures = {}
+    file_paths = getattr(args, "/path/to/description.s4ext")
+    for file_path in file_paths:
+        extension_name, failures = _check_extension(file_path)
+        extension_failures[extension_name] = failures
 
     total_failure_count = 0
 

--- a/scripts/check_description_files.py
+++ b/scripts/check_description_files.py
@@ -97,8 +97,8 @@ def check_screenshoturls(extension_name, metadata):
     if metadata["screenshoturls"] is None:
         return
     for screenshoturl in metadata["screenshoturls"].split(" "):
-        if not screenshoturl.startswith("http"):
-            msg = f"screenshoturl is `{screenshoturl}` but it does not start with http"
+        if not screenshoturl.startswith("https://"):
+            msg = f"screenshoturl is `{screenshoturl}` but it does not start with https"
             raise ExtensionCheckError(extension_name, check_name, msg)
 
 

--- a/scripts/check_description_files.py
+++ b/scripts/check_description_files.py
@@ -243,9 +243,6 @@ def main():
     parser = argparse.ArgumentParser(
         description='Validate extension description files.')
     parser.add_argument(
-        "--check-git-repository-name", action="store_true",
-        help="Check extension git repository name. Disabled by default.")
-    parser.add_argument(
         "--check-urls-reachable", action="store_true",
         help="Check homepage, iconurl and screenshoturls are reachable. Disabled by default.")
     parser.add_argument("-d", "--check-dependencies", help="Check all extension dsecription files in the provided folder.")
@@ -254,14 +251,12 @@ def main():
 
     checks = []
 
-    if args.check_git_repository_name:
-        checks.append((check_git_repository_name, {}))
-
     if not checks:
         checks = [
             (check_category, {}),
             (check_contributors, {}),
             (check_description, {}),
+            (check_git_repository_name, {}),
             (check_homepage, {"check_url_reachable": args.check_urls_reachable}),
             (check_iconurl, {"check_url_reachable": args.check_urls_reachable}),
             (check_scmurl_syntax, {}),

--- a/scripts/check_description_files.py
+++ b/scripts/check_description_files.py
@@ -157,7 +157,9 @@ def check_dependencies(directory):
         f = os.path.join(directory, filename)
         if not os.path.isfile(f):
             continue
-        extension_name = os.path.splitext(os.path.basename(filename))[0]
+        extension_name, extension = os.path.splitext(os.path.basename(filename))
+        if extension != ".s4ext":
+            continue
         available_extensions.append(extension_name)
         extension_description = parse_s4ext(f)
         if 'depends' not in extension_description:

--- a/scripts/check_description_files.py
+++ b/scripts/check_description_files.py
@@ -77,8 +77,8 @@ def check_description(*_unused_args):
 def check_homepage(extension_name, metadata):
     check_name = "check_homepage"
     homepage = metadata["homepage"]
-    if not homepage.startswith("http"):
-        msg = f"homepage is `{homepage}` but it does not start with http"
+    if not homepage.startswith("https://"):
+        msg = f"homepage is `{homepage}` but it does not start with https"
         raise ExtensionCheckError(extension_name, check_name, msg)
 
 

--- a/scripts/check_description_files.py
+++ b/scripts/check_description_files.py
@@ -44,7 +44,7 @@ class ExtensionCheckError(RuntimeError):
         return self.details
 
 
-def check_url(url, timeout=1):
+def check_url(url, timeout=3):
 
     @retry(TimeoutError, tries=3, delay=1, jitter=1, max_delay=3)
     def _check_url():

--- a/slicerPRISMRendering.s4ext
+++ b/slicerPRISMRendering.s4ext
@@ -27,7 +27,7 @@ iconurl https://raw.githubusercontent.com/ETS-vis-interactive/SlicerPRISMRenderi
 status beta
 
 # One line stating what the module does
-This module is an implementation of the PRISM customizable volume rendering framework in 3D Slicer.
+description This module is an implementation of the PRISM customizable volume rendering framework in 3D Slicer.
 
 # Space separated list of urls
 screenshoturls https://raw.githubusercontent.com/ETS-vis-interactive/SlicerPRISMRendering/master/docs/source/images/screenshotSlicerPRISMRendering.png


### PR DESCRIPTION
Before moving forward with the transition from `.s4ext` to `.json`, we are following these steps:
1. Fix the extension metadata in the `.s4ext` files
2. Update the `CMakeLists.txt` in each extension GitHub repository with the correct values

This pull request corresponds to the first step.

Remaining updates for _step 1_:
* [x] Add missing metadata
* [x] Update `homepage` URL to use https
* [x] Update `iconurl` URL to use https
* [x] Update `screenshoturls` to use https
* [x] Update `check_description_files` to check URLs are reachable
* [x] Fix URLs
* [x] Update CircleCI config to run check with `--check-urls-reachable`


Related pull requests:
* https://github.com/Slicer/Slicer/pull/7629
* https://github.com/Slicer/ExtensionsIndex/pull/2011