### PR TITLE
Use SlicerAutomatedDentalTools and SlicerDentalModelSeg 5.6 branches

### DIFF
--- a/AutomatedDentalTools.s4ext
+++ b/AutomatedDentalTools.s4ext
@@ -8,7 +8,7 @@
 # This is source code manager
 scm git
 scmurl https://github.com/DCBIA-OrthoLab/SlicerAutomatedDentalTools.git
-scmrevision main
+scmrevision 5.6
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files

--- a/SlicerDentalModelSeg.s4ext
+++ b/SlicerDentalModelSeg.s4ext
@@ -8,7 +8,7 @@
 # This is source code manager
 scm git
 scmurl https://github.com/DCBIA-OrthoLab/SlicerDentalModelSeg.git
-scmrevision main
+scmrevision 5.6
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files


### PR DESCRIPTION
main on these extensions now depends on SlicerConda, which is not available in Slicer preview. To avoid testing/backporting SlicerConda to 5.6, instead revert those changes and use a dedicated 5.6 branch on these extensions.

https://github.com/DCBIA-OrthoLab/SlicerAutomatedDentalTools/tree/5.6

https://github.com/DCBIA-OrthoLab/SlicerDentalModelSeg/tree/5.6

cc @GaelleLeroux is there anything else blocking this from your side?