### PR TITLE
BUG: Attempt to fix schema download using jsdelivr instead of GitHub raw

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
         args:
           [
             "--schemafile",
-            "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json",
+            "https://cdn.jsdelivr.net/gh/Slicer/Slicer@main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json",
           ]
       - id: check-dependabot
       - id: check-github-workflows


### PR DESCRIPTION
See https://www.jsdelivr.com/?docs=gh and https://rawgit.com/

Attempt to fix error like the following:

```
Error: schemafile could not be parsed as JSON
SchemaParseError: https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json
  in "/home/runner/.cache/pre-commit/repof4twk6ja/py_env-python3.9/lib/python3.9/site-packages/check_jsonschema/checker.py", line 53
  >>> return self._schema_loader.get_validator(

  caused by

  FailedFileLoadError: Failed to parse https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json
    in "/home/runner/.cache/pre-commit/repof4twk6ja/py_env-python3.9/lib/python3.9/site-packages/check_jsonschema/schema_loader/readers.py", line 27
    >>> schema = callback()

    caused by

    JSONDecodeError: Expecting value: line 1 column 1 (char 0)
      in "/home/runner/.cache/pre-commit/repof4twk6ja/py_env-python3.9/lib/python3.9/site-packages/check_jsonschema/parsers/__init__.py", line 92
      >>> return loadfunc(data)

      caused by

      StopIteration: 0
        in "/opt/hostedtoolcache/Python/3.9.19/x64/lib/python3.9/json/decoder.py", line 353
        >>> obj, end = self.scan_once(s, idx)
```

Source: https://github.com/Slicer/ExtensionsIndex/actions/runs/9520665504/job/26246426798?pr=2055