### PR TITLE
Update LungCTAnalyzer repository URL - main branch

### DIFF
--- a/LungCTAnalyzer.json
+++ b/LungCTAnalyzer.json
@@ -8,5 +8,5 @@
   "build_subdirectory": ".",
   "category": "Chest Imaging Platform",
   "scm_revision": "master",
-  "scm_url": "https://github.com/rbumm/SlicerLungCTAnalyzer"
+  "scm_url": "https://github.com/Slicer/SlicerLungCTAnalyzer"
 }


### PR DESCRIPTION
The repository was moved from a Rudolf Bumm's personal github account (rbumm) to the Slicer organization.
