### PR TITLE
ENH: Adds new dependencies to SlicerMorph.s4ext

### DIFF
--- a/SlicerMorph.s4ext
+++ b/SlicerMorph.s4ext
@@ -12,7 +12,7 @@ scmrevision 5.6
 # list dependencies
 # - These should be names of other modules that have .s4ext files
 # - The dependencies will be built first
-depends     SegmentEditorExtraEffects
+depends     SegmentEditorExtraEffects Sandbox SurfaceMarkup
 
 # Inner build directory (default is .)
 build_subdirectory .


### PR DESCRIPTION
Adds Sandbox and SurfaceMarkup as dependencies to the SlicerMorph extension.