### PR TITLE
ENH: Add SurfaceMarkup as a dependency to SlicerMorph.json

### DIFF
--- a/SlicerMorph.json
+++ b/SlicerMorph.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
-  "build_dependencies": ["SegmentEditorExtraEffects"],
+  "build_dependencies": ["SegmentEditorExtraEffects", "SurfaceMarkup"],
   "build_subdirectory": ".",
   "category": "SlicerMorph",
   "scm_revision": "master",


### PR DESCRIPTION
The SurfaceMarkup extension is necessary for the PlaceLandmarkGrid module in SlicerMorph and is currently installed when this module is opened. Since we are now adding support to interact with the generated grids to other modules, this is no longer the best solution. 

Additionally, when running SlicerMorph in a cloud environment, it works best if dependencies are downloaded and installed at the same time as the extension. Adding SurfaceMarkup as an extension dependency will accomplish this also.

