### PR TITLE
ENH: Update repo to original owner (CSIMLab) and set to 5.6 branch

### DIFF
--- a/AnomalousFiltersExtension.s4ext
+++ b/AnomalousFiltersExtension.s4ext
@@ -6,8 +6,8 @@
 
 # This is source code manager
 scm git
-scmurl https://github.com/lassoan/AnomalousFiltersExtension.git
-scmrevision master
+scmurl https://github.com/CSIM-Toolkits/AnomalousFiltersExtension.git
+scmrevision 5.6
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files
@@ -18,7 +18,7 @@ depends NA
 build_subdirectory .
 
 # homepage
-homepage http://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/AnomalousFilters
+homepage https://anomalousfiltersextension.readthedocs.io/en/latest/
 
 # Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
 # For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)
@@ -28,7 +28,7 @@ contributors Antonio Carlos Senra Filho (University of Sao Paulo), Luiz Otavio M
 category Filtering
 
 # url to icon (png, size 128x128 pixels)
-iconurl https://www.slicer.org/slicerWiki/images/8/89/AnomalousDiffusionExtension-logo.png
+iconurl https://raw.githubusercontent.com/CSIM-Toolkits/AnomalousFiltersExtension/refs/heads/5.6/AnomalousFiltersExtension.png
 
 # Give people an idea what to expect from this code
 #  - Is it just a test or something you stand behind?
@@ -38,7 +38,7 @@ status
 description This extension aims to provide several approaches in order to apply the anomalous spatial filters on medical images. The methods provided here are numerical solution of the generalized anomalous diffusion proposed by Constantino Tsallis, which, in other words, provide a numerical solution to the porous media equation (Fokker-Planck anomalous heat equation). At the moment, the Modules available are suppose to be used on MRI volumes namely T1, T2, T2-FLAIR and PD weighted images, and diffusion weighted images (DWI and DTI). Future developments will add new functionalities in order to attenuate image noise in other imaging modalities. More details could be found in the wiki page.
 
 # Space separated list of urls
-screenshoturls https://www.slicer.org/slicerWiki/images/6/64/MRI_raw.png https://www.slicer.org/slicerWiki/images/e/e8/MRI_AAD.png https://www.slicer.org/slicerWiki/images/0/0d/MRI_IAD.png https://www.slicer.org/w/images/4/40/DTI_FA_raw.png https://www.slicer.org/w/images/7/7c/DTI_FA_AAD.png https://www.slicer.org/w/images/a/a0/Tractography_AAD.png
+screenshoturls https://raw.githubusercontent.com/CSIM-Toolkits/AnomalousFiltersExtension/refs/heads/5.6/docs/assets/MRI_raw.png https://raw.githubusercontent.com/CSIM-Toolkits/AnomalousFiltersExtension/refs/heads/5.6/docs/assets/MRI_AAD.png https://raw.githubusercontent.com/CSIM-Toolkits/AnomalousFiltersExtension/refs/heads/5.6/docs/assets/MRI_IAD.png https://raw.githubusercontent.com/CSIM-Toolkits/AnomalousFiltersExtension/refs/heads/5.6/docs/assets/DTI_FA_raw.png https://raw.githubusercontent.com/CSIM-Toolkits/AnomalousFiltersExtension/refs/heads/5.6/docs/assets/DTI_FA_AAD.png
 
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 1


### PR DESCRIPTION
This is only an Extension Index update to:

1. Return to the original repository owner (CSIM Lab)
2. Informs the new branch 5.6, that indicates the most recent Slicer stable at the moment
3. Update the image links to rwa github address (screenshots and icon)
4. Update the repo documentation website, since the Slicer Wiki will be retired in the near future