### PR TITLE
ENH: Add Diffusion Complexity to Slicer 5.6

### DIFF
--- a/DiffusionComplexityMap.s4ext
+++ b/DiffusionComplexityMap.s4ext
@@ -1,0 +1,44 @@
+#
+# First token of each non-comment line is the keyword and the rest of the line
+# (including spaces) is the value.
+# - the value can be blank
+#
+
+# This is source code manager
+scm git
+scmurl https://github.com/CSIM-Toolkits/SlicerDiffusionComplexityMap.git
+scmrevision 5.6
+
+# list dependencies
+# - These should be names of other modules that have .s4ext files
+# - The dependencies will be built first
+depends NA
+
+# Inner build directory (default is ".")
+build_subdirectory .
+
+# homepage
+homepage https://slicerdiffusioncomplexitymap.readthedocs.io/en/latest/
+
+# Firstname1 Lastname1 ([SubOrg1, ]Org1), Firstname2 Lastname2 ([SubOrg2, ]Org2)
+# For example: Jane Roe (Superware), John Doe (Lab1, Nowhere), Joe Bloggs (Noware)
+contributors Antonio Carlos Senra Filho (University of Campinas, Brazil), Andre M. Paschoal (University of Campinas, Brazil), Luiz Otavio Murta Junior (University of Sao Paulo, Brazil)
+
+# Match category in the xml description of the module (where it shows up in Modules menu)
+category Diffusion
+
+# url to icon (png, size 128x128 pixels)
+iconurl https://raw.githubusercontent.com/CSIM-Toolkits/SlicerDiffusionComplexityMap/main/DiffusionComplexityMap.png
+
+# Give people an idea what to expect from this code
+#  - Is it just a test or something you stand behind?
+status 
+
+# One line stating what the module does
+description This extension provides the Diffusion Complexity map based for diffusion imaging sequences (assuming DTI imaging protocol). This algorithm results in an diffusion scalar mapping based on the LMC complexity metric, infering micro-structural tissue complexity measurement.
+
+# Space separated list of urls
+screenshoturls https://raw.githubusercontent.com/CSIM-Toolkits/SlicerDiffusionComplexityMap/refs/heads/main/docs/assets/FA_diff_example.png https://raw.githubusercontent.com/CSIM-Toolkits/SlicerDiffusionComplexityMap/refs/heads/main/docs/assets/ADC_diff_example.png https://raw.githubusercontent.com/CSIM-Toolkits/SlicerDiffusionComplexityMap/refs/heads/main/docs/assets/DC_diff_example.png
+
+# 0 or 1: Define if the extension should be enabled after its installation.
+enabled 1


### PR DESCRIPTION
This is only an Extension Index update to:

1. Informs the new branch 5.6, which indicates the most recent Slicer stable at the moment
2. Update the repo documentation website, since the Slicer Wiki will be retired in the near future