### PR TITLE
Specify "tier" for each extension

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,27 +6,56 @@ Thank you for contributing to 3D Slicer!
 
 # New extension
 
-<!-- To make sure users can find your extension, understand what it is intended for and how to use it, please complete the checklist below. You do not need to complete all the item by the time you submit the pull request, but most likely the changes will only be merged if all the tasks are done. See more information about the submission process here: https://slicer.readthedocs.io/en/latest/developer_guide/extensions.html -->
+<!-- To make sure users can find your extension, understand what it is intended for and how to use it, please complete the checklist below. You do not need to complete all the item by the time you submit the pull request, but most likely the changes will only be merged if all the tasks are done. "Tier" of your extension will be determined based on the set of requirements you fulfill. See more information about the submission process here: https://slicer.readthedocs.io/en/latest/developer_guide/extensions.html.
+ -->
+
+
+## Tier 1
+
+Any extension that is listed in the Extensions Catalog must fulfill these requirements.
 
 - [ ] Extension has a reasonable name (not too general, not too narrow, suggests what the extension is for)
-- [ ] Repository name is Slicer+ExtensionName
+- [ ] Repository name is Slicer+ExtensionName (except if the repository that hosts the extension can be also used without Slicer)
 - [ ] Repository is associated with `3d-slicer-extension` GitHub topic so that it is listed [here](https://github.com/topics/3d-slicer-extension). To edit topics, click the settings icon in the right side of "About" section header and enter `3d-slicer-extension` in "Topics" and click "Save changes". To learn more about topics, read https://help.github.com/en/articles/about-topics
 - [ ] Extension description summarizes in 1-2 sentences what the extension is usable (should be understandable for non-experts)
 - [ ] Any known related patents must be mentioned in the extension description.
-- [ ] LICENSE.txt is present in the repository root. MIT  (https://choosealicense.com/licenses/mit/) or Apache (https://choosealicense.com/licenses/apache-2.0/) license is recommended. If source code license is more restrictive for users than MIT, BSD, Apache, or 3D Slicer license then the name of the used license must be mentioned in the extension description.
+- [ ] LICENSE.txt is present in the repository root and the name of the license is mentioned in extension homepage. We suggest you use a permissive license that includes patent and contribution clauses. This will help protect developers and ensure the code remains freely available. MIT (https://choosealicense.com/licenses/mit/) or Apache (https://choosealicense.com/licenses/apache-2.0/) license is recommended. Read [here](https://opensource.guide/legal/#which-open-source-license-is-appropriate-for-my-project) to learn more about licenses. If source code license is more restrictive for users than MIT, BSD, Apache, or 3D Slicer license then describe the reason for the license choice and include the name of the used license in the extension description.
 - [ ] Extension URL and revision (scmurl, scmrevision) is correct, consider using a branch name (main, release, ...) instead of a specific git hash to avoid re-submitting pull request whenever the extension is updated
 - [ ] Extension icon URL is correct (do not use the icon's webpage but the raw data download URL that you get from the download button - it should look something like this: https://raw.githubusercontent.com/user/repo/main/SomeIcon.png)
 - [ ] Screenshot URLs (screenshoturls) are correct, contains at least one
-- [ ] Homepage URL points to valid webpage containing the following:
+- [ ] Content of submitted json file is consistent with the top-level CMakeLists.txt file in the repository (dependencies, etc. are the same)
+- Homepage URL points to valid webpage containing the following:
   - [ ] Extension name
   - [ ] Short description: 1-2 sentences, which summarizes what the extension is usable for
   - [ ] At least one nice, informative image, that illustrates what the extension can do. It may be a screenshot.
   - [ ] Description of contained modules: at one sentence for each module
-  - [ ] Tutorial: step-by-step description of at least the most typical use case, include a few screenshots, provide download links to sample input data set
   - [ ] Publication: link to publication and/or to PubMed reference (if available)
-  - [ ] License: We suggest you use a permissive license that includes patent and contribution clauses.  This will help protect developers and ensure the code remains freely available.  We suggest you use the [Slicer License](https://github.com/Slicer/Slicer/blob/main/License.txt) or the [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0). Always mention in your README file the license you have chosen.  If you choose a different license, explain why to the extension maintainers. Depending on the license we may not be able to host your work. Read [here](https://opensource.guide/legal/#which-open-source-license-is-appropriate-for-my-project) to learn more about licenses.
-  - [ ] Content of submitted json file is consistent with the top-level CMakeLists.txt file in the repository (dependencies, etc. are the same)
-- Hide unused features in the repository to reduce noise/irrelevant information:
-  - [ ] Click `Settings` and in repository settings uncheck `Wiki`, `Projects`, and `Discussions` (if they are currently not used)
+- Hide unused github features (such as Wiki, Projects, and Discussions, Releases, Packages) in the repository to reduce noise/irrelevant information:
+  - [ ] Click `Settings` and in repository settings uncheck `Wiki`, `Projects`, and `Discussions` (if they are currently not used).
   - [ ] Click the settings icon next to `About` in the top-right corner of the repository main page and uncheck `Releases` and `Packages` (if they are currently not used)
-<!-- If you have any questions or comments then please describe them here. -->
+- The extension is safe:
+  - [ ] Does not include or download binaries from unreliable sources
+  - [ ] Does not send any information anywhere without user consent (explicit opt-in is required)
+
+## Tier 3
+
+Community-supported extensions.
+
+- [ ] Documentation, tutorial, and test data are provided for most modules. A tutorial provides step-by-step description of at least the most typical use case, include a few screenshots. Any sample data sets that is used in tutorials must be registered with the Sample Data module to provide easy access to the user.
+- [ ] Follows programming and user interface conventions of 3D Slicer (e.g., GUI and logic are separated, usage of popups is minimized, no unnecessary custom GUI styling, etc.)
+- [ ] The extension can be successfully built and packaged on all supported platforms (Windows, macOS, Linux)
+- [ ] Maintainers respond to issues and pull request submitted to the extension's repository.
+- [ ] Maintainers respond to questions directly addressed to him/her via @mention on the [Slicer Forum](https://discourse.slicer.org).
+- [ ] Permissive license is used for the main functions of the extension (recommended Apache or MIT). The extension can provide additional functionality in optional components that are distributed with non-permissive license, but the user has to explicitly approve those before using them (e.g., a pop-up can be displayed that explains the licensing terms and the user has to acknowledge them to proceed).
+- All requirements of tiers < 3.
+
+## Tier 5
+
+Critically important extensions, supported by Slicer core developers. New Slicer Stable Release is released only if all Tier 5 extension packages are successfully created on all supported platforms.
+
+- [ ] Slicer core developers accept the responsibility of fixing any issues caused by Slicer core changes; at least one Slicer core developer (anyone who has commit right to Slicer core) must be granted commit right to the extension's repository.
+- [ ] Automated tests for all critical features.
+- [ ] Maintainers respond to questions related to the extension on the [Slicer Forum](https://discourse.slicer.org).
+- All requirements of tiers < 5.
+
+<!-- Feel free to add any questions or comments here. -->

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
         args:
           [
             "--schemafile",
-            "http://cdn.jsdelivr.net/gh/Slicer/Slicer@main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json",
+            "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json",
           ]
       - id: check-dependabot
       - id: check-github-workflows

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
         args:
           [
             "--schemafile",
-            "http://cdn.jsdelivr.net/gh/Slicer/Slicer@main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json",
+            "http://cdn.jsdelivr.net/gh/Slicer/Slicer@main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json",
           ]
       - id: check-dependabot
       - id: check-github-workflows

--- a/ABLTemporalBoneSegmentation.json
+++ b/ABLTemporalBoneSegmentation.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": ["SlicerElastix"],
   "build_subdirectory": "inner-build",
   "category": "Otolaryngology",
   "scm_revision": "master",
-  "scm_url": "https://github.com/Auditory-Biophysics-Lab/Slicer-ABLTemporalBoneSegmentation"
+  "scm_url": "https://github.com/Auditory-Biophysics-Lab/Slicer-ABLTemporalBoneSegmentation",
+  "tier": 1
 }

--- a/AblationPlanner.json
+++ b/AblationPlanner.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": ["ModelToModelDistance"],
   "build_subdirectory": ".",
   "category": "Quantification",
   "scm_revision": "main",
-  "scm_url": "https://github.com/naterex23/SlicerAblationPlanner"
+  "scm_url": "https://github.com/naterex23/SlicerAblationPlanner",
+  "tier": 3
 }

--- a/AirwaySegmentation.json
+++ b/AirwaySegmentation.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Segmentation",
   "scm_revision": "master",
-  "scm_url": "https://github.com/Slicer/SlicerAirwaySegmentation"
+  "scm_url": "https://github.com/Slicer/SlicerAirwaySegmentation",
+  "tier": 1
 }

--- a/AnglePlanesExtension.json
+++ b/AnglePlanesExtension.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Shape Analysis",
   "scm_revision": "master",
-  "scm_url": "https://github.com/DCBIA-OrthoLab/AnglePlanes-Extension.git"
+  "scm_url": "https://github.com/DCBIA-OrthoLab/AnglePlanes-Extension.git",
+  "tier": 1
 }

--- a/AnomalousFiltersExtension.json
+++ b/AnomalousFiltersExtension.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Filtering",
   "scm_revision": "main",
-  "scm_url": "https://github.com/CSIM-Toolkits/AnomalousFiltersExtension.git"
+  "scm_url": "https://github.com/CSIM-Toolkits/AnomalousFiltersExtension.git",
+  "tier": 3
 }

--- a/ArduinoController.json
+++ b/ArduinoController.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Developer Tools",
   "scm_revision": "master",
-  "scm_url": "https://github.com/pzaffino/SlicerArduinoController.git"
+  "scm_url": "https://github.com/pzaffino/SlicerArduinoController.git",
+  "tier": 3
 }

--- a/AstmPhantomTest.json
+++ b/AstmPhantomTest.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": ["SlicerOpenIGTLink"],
   "build_subdirectory": ".",
   "category": "IGT",
   "scm_revision": "master",
-  "scm_url": "https://github.com/Atracsys/SlicerAstmPhantomTest.git"
+  "scm_url": "https://github.com/Atracsys/SlicerAstmPhantomTest.git",
+  "tier": 3
 }

--- a/Auto3dgm.json
+++ b/Auto3dgm.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Auto3dgm",
   "scm_revision": "master",
-  "scm_url": "https://github.com/ToothAndClaw/SlicerAuto3dgm"
+  "scm_url": "https://github.com/ToothAndClaw/SlicerAuto3dgm",
+  "tier": 1
 }

--- a/AutomatedDentalTools.json
+++ b/AutomatedDentalTools.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": ["SlicerDentalModelSeg", "SlicerConda"],
   "build_subdirectory": ".",
   "category": "Segmentation",
   "scm_revision": "main",
-  "scm_url": "https://github.com/DCBIA-OrthoLab/SlicerAutomatedDentalTools.git"
+  "scm_url": "https://github.com/DCBIA-OrthoLab/SlicerAutomatedDentalTools.git",
+  "tier": 3
 }

--- a/Autoscroll.json
+++ b/Autoscroll.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Segmentation",
   "scm_revision": "master",
-  "scm_url": "https://github.com/lassoan/SlicerAutoscroll"
+  "scm_url": "https://github.com/lassoan/SlicerAutoscroll",
+  "tier": 3
 }

--- a/BigImage.json
+++ b/BigImage.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "BigImage",
   "scm_revision": "main",
-  "scm_url": "https://github.com/gaoyi/SlicerBigImage.git"
+  "scm_url": "https://github.com/gaoyi/SlicerBigImage.git",
+  "tier": 1
 }

--- a/BoneReconstructionPlanner.json
+++ b/BoneReconstructionPlanner.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": ["SurfaceWrapSolidify", "MarkupsToModel", "Sandbox"],
   "build_subdirectory": ".",
   "category": "Planning",
   "scm_revision": "main",
-  "scm_url": "https://github.com/SlicerIGT/SlicerBoneReconstructionPlanner.git"
+  "scm_url": "https://github.com/SlicerIGT/SlicerBoneReconstructionPlanner.git",
+  "tier": 3
 }

--- a/BoneTextureExtension.json
+++ b/BoneTextureExtension.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": "inner-build",
   "category": "Quantification",
   "scm_revision": "master",
-  "scm_url": "https://github.com/Kitware/BoneTextureExtension.git"
+  "scm_url": "https://github.com/Kitware/BoneTextureExtension.git",
+  "tier": 3
 }

--- a/BoneThicknessMapping.json
+++ b/BoneThicknessMapping.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Shape Analysis",
   "scm_revision": "master",
-  "scm_url": "https://github.com/Auditory-Biophysics-Lab/SlicerBoneThicknessMappingExtension"
+  "scm_url": "https://github.com/Auditory-Biophysics-Lab/SlicerBoneThicknessMappingExtension",
+  "tier": 1
 }

--- a/BrainVolumeRefinement.json
+++ b/BrainVolumeRefinement.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Segmentation",
   "scm_revision": "main",
-  "scm_url": "https://github.com/CSIM-Toolkits/SlicerBrainVolumeRefinement.git"
+  "scm_url": "https://github.com/CSIM-Toolkits/SlicerBrainVolumeRefinement.git",
+  "tier": 3
 }

--- a/BreastImplantAnalyzer.json
+++ b/BreastImplantAnalyzer.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Quantification",
   "scm_revision": "master",
-  "scm_url": "https://github.com/lassoan/SlicerBreastImplantAnalyzer.git"
+  "scm_url": "https://github.com/lassoan/SlicerBreastImplantAnalyzer.git",
+  "tier": 3
 }

--- a/BreastUltrasoundAnalysis.json
+++ b/BreastUltrasoundAnalysis.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": ["PyTorch"],
   "build_subdirectory": ".",
   "category": "Utilities",
   "scm_revision": "master",
-  "scm_url": "https://github.com/ZhyBrian/SlicerBreastUltrasoundAnalysis.git"
+  "scm_url": "https://github.com/ZhyBrian/SlicerBreastUltrasoundAnalysis.git",
+  "tier": 3
 }

--- a/Breast_DCEMRI_FTV.json
+++ b/Breast_DCEMRI_FTV.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "FTV Segmentation",
   "scm_revision": "master",
-  "scm_url": "https://github.com/radiology-research/SlicerBreast_DCEMRI_FTV"
+  "scm_url": "https://github.com/radiology-research/SlicerBreast_DCEMRI_FTV",
+  "tier": 1
 }

--- a/CBCTToothSegmentation.json
+++ b/CBCTToothSegmentation.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Segmentation",
   "scm_revision": "master",
-  "scm_url": "https://github.com/KitwareMedical/SlicerCBCTToothSegmentation.git"
+  "scm_url": "https://github.com/KitwareMedical/SlicerCBCTToothSegmentation.git",
+  "tier": 3
 }

--- a/CMFreg.json
+++ b/CMFreg.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Registration",
   "scm_revision": "master",
-  "scm_url": "https://github.com/DCBIA-OrthoLab/CMFreg.git"
+  "scm_url": "https://github.com/DCBIA-OrthoLab/CMFreg.git",
+  "tier": 3
 }

--- a/CarreraSlice.json
+++ b/CarreraSlice.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Segmentation",
   "scm_revision": "master",
-  "scm_url": "https://github.com/ikolesov/CarreraSlice.git"
+  "scm_url": "https://github.com/ikolesov/CarreraSlice.git",
+  "tier": 1
 }

--- a/ChangeTracker.json
+++ b/ChangeTracker.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Wizards",
   "scm_revision": "master",
-  "scm_url": "https://github.com/fedorov/ChangeTrackerPy.git"
+  "scm_url": "https://github.com/fedorov/ChangeTrackerPy.git",
+  "tier": 1
 }

--- a/Chest_Imaging_Platform.json
+++ b/Chest_Imaging_Platform.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": "inner-build",
   "category": "Chest Imaging Platform",
   "scm_revision": "develop",
-  "scm_url": "https://github.com/acil-bwh/SlicerCIP"
+  "scm_url": "https://github.com/acil-bwh/SlicerCIP",
+  "tier": 3
 }

--- a/CleverSeg.json
+++ b/CleverSeg.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Segmentation",
   "scm_revision": "master",
-  "scm_url": "https://github.com/lassoan/SlicerCleverSegmentation.git"
+  "scm_url": "https://github.com/lassoan/SlicerCleverSegmentation.git",
+  "tier": 1
 }

--- a/ColocZStats.json
+++ b/ColocZStats.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Quantification",
   "scm_revision": "main",
-  "scm_url": "https://github.com/ChenXiang96/SlicerColoc-Z-Stats.git"
+  "scm_url": "https://github.com/ChenXiang96/SlicerColoc-Z-Stats.git",
+  "tier": 3
 }

--- a/ConnectToSupervisely.json
+++ b/ConnectToSupervisely.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Supervisely",
   "scm_revision": "master",
-  "scm_url": "https://github.com/supervisely-ecosystem/SlicerConnectToSupervisely"
+  "scm_url": "https://github.com/supervisely-ecosystem/SlicerConnectToSupervisely",
+  "tier": 1
 }

--- a/CurveMaker.json
+++ b/CurveMaker.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Informatics",
   "scm_revision": "master",
-  "scm_url": "https://github.com/tokjun/CurveMaker"
+  "scm_url": "https://github.com/tokjun/CurveMaker",
+  "tier": 1
 }

--- a/DCMQI.json
+++ b/DCMQI.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": "dcmqi-build",
   "category": "DICOM",
   "scm_revision": "master",
-  "scm_url": "https://github.com/QIICR/dcmqi.git"
+  "scm_url": "https://github.com/QIICR/dcmqi.git",
+  "tier": 5
 }

--- a/DICOMwebBrowser.json
+++ b/DICOMwebBrowser.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Informatics",
   "scm_revision": "main",
-  "scm_url": "https://github.com/lassoan/SlicerDICOMwebBrowser"
+  "scm_url": "https://github.com/lassoan/SlicerDICOMwebBrowser",
+  "tier": 5
 }

--- a/DRRGenerator.json
+++ b/DRRGenerator.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Filtering",
   "scm_revision": "master",
-  "scm_url": "https://github.com/lassoan/SlicerDRRGenerator.git"
+  "scm_url": "https://github.com/lassoan/SlicerDRRGenerator.git",
+  "tier": 1
 }

--- a/DSCMRIAnalysis.json
+++ b/DSCMRIAnalysis.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Quantification",
   "scm_revision": "master",
-  "scm_url": "https://github.com/QIICR/DSC_Analysis.git"
+  "scm_url": "https://github.com/QIICR/DSC_Analysis.git",
+  "tier": 3
 }

--- a/DatabaseInteractor.json
+++ b/DatabaseInteractor.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Web System Tools",
   "scm_revision": "master",
-  "scm_url": "https://github.com/DCBIA-OrthoLab/DatabaseInteractorExtension.git"
+  "scm_url": "https://github.com/DCBIA-OrthoLab/DatabaseInteractorExtension.git",
+  "tier": 1
 }

--- a/DebuggingTools.json
+++ b/DebuggingTools.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Developer Tools",
   "scm_revision": "master",
-  "scm_url": "https://github.com/SlicerRt/SlicerDebuggingTools.git"
+  "scm_url": "https://github.com/SlicerRt/SlicerDebuggingTools.git",
+  "tier": 5
 }

--- a/DensityLungSegmentation.json
+++ b/DensityLungSegmentation.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Segmentation",
   "scm_revision": "main",
-  "scm_url": "https://github.com/pzaffino/SlicerDensityLungSegmentation.git"
+  "scm_url": "https://github.com/pzaffino/SlicerDensityLungSegmentation.git",
+  "tier": 3
 }

--- a/DentalSegmentator.json
+++ b/DentalSegmentator.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": ["NNUNet"],
   "build_subdirectory": ".",
   "category": "Segmentation",
   "scm_revision": "main",
-  "scm_url": "https://github.com/gaudot/SlicerDentalSegmentator"
+  "scm_url": "https://github.com/gaudot/SlicerDentalSegmentator",
+  "tier": 3
 }

--- a/DeveloperToolsForExtensions.json
+++ b/DeveloperToolsForExtensions.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Developer Tools",
   "scm_revision": "master",
-  "scm_url": "https://github.com/Slicer/SlicerDeveloperToolsForExtensions.git"
+  "scm_url": "https://github.com/Slicer/SlicerDeveloperToolsForExtensions.git",
+  "tier": 5
 }

--- a/DiffusionQC.json
+++ b/DiffusionQC.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": ["SlicerDMRI"],
   "build_subdirectory": ".",
   "category": "Diffusion",
   "scm_revision": "master",
-  "scm_url": "https://github.com/pnlbwh/SlicerDiffusionQC"
+  "scm_url": "https://github.com/pnlbwh/SlicerDiffusionQC",
+  "tier": 3
 }

--- a/EasyClip.json
+++ b/EasyClip.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Shape Analysis",
   "scm_revision": "master",
-  "scm_url": "https://github.com/DCBIA-OrthoLab/EasyClip-Extension.git"
+  "scm_url": "https://github.com/DCBIA-OrthoLab/EasyClip-Extension.git",
+  "tier": 3
 }

--- a/ErodeDilateLabel.json
+++ b/ErodeDilateLabel.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Filtering.Morphology",
   "scm_revision": "master",
-  "scm_url": "https://github.com/tokjun/ErodeDilateLabel.git"
+  "scm_url": "https://github.com/tokjun/ErodeDilateLabel.git",
+  "tier": 1
 }

--- a/ExtraMarkups.json
+++ b/ExtraMarkups.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Utilities",
   "scm_revision": "main",
-  "scm_url": "https://github.com/chir-set/SlicerExtraMarkups.git"
+  "scm_url": "https://github.com/chir-set/SlicerExtraMarkups.git",
+  "tier": 3
 }

--- a/FiducialsToModelDistance.json
+++ b/FiducialsToModelDistance.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Quantification",
   "scm_revision": "master",
-  "scm_url": "https://github.com/ReynoldsJ20/SlicerFiducialsToModelDistance"
+  "scm_url": "https://github.com/ReynoldsJ20/SlicerFiducialsToModelDistance",
+  "tier": 3
 }

--- a/FilmDosimetryAnalysis.json
+++ b/FilmDosimetryAnalysis.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": ["SlicerRT"],
   "build_subdirectory": ".",
   "category": "Radiotherapy",
   "scm_revision": "master",
-  "scm_url": "https://github.com/SlicerRt/FilmDosimetryAnalysis.git"
+  "scm_url": "https://github.com/SlicerRt/FilmDosimetryAnalysis.git",
+  "tier": 3
 }

--- a/FlywheelCaseIterator.json
+++ b/FlywheelCaseIterator.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": ["SlicerDevelopmentToolbox"],
   "build_subdirectory": ".",
   "category": "Informatics",
   "scm_revision": "main",
-  "scm_url": "https://gitlab.com/flywheel-io/scientific-solutions/app/Slicerflywheelcaseiterator.git"
+  "scm_url": "https://gitlab.com/flywheel-io/scientific-solutions/app/Slicerflywheelcaseiterator.git",
+  "tier": 1
 }

--- a/GelDosimetryAnalysis.json
+++ b/GelDosimetryAnalysis.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": ["SlicerRT"],
   "build_subdirectory": ".",
   "category": "Radiotherapy",
   "scm_revision": "master",
-  "scm_url": "https://github.com/SlicerRt/GelDosimetryAnalysis.git"
+  "scm_url": "https://github.com/SlicerRt/GelDosimetryAnalysis.git",
+  "tier": 3
 }

--- a/GeodesicSlicer.json
+++ b/GeodesicSlicer.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Informatics",
   "scm_revision": "master",
-  "scm_url": "https://github.com/FredericBr/SlicerGeodesic"
+  "scm_url": "https://github.com/FredericBr/SlicerGeodesic",
+  "tier": 3
 }

--- a/GyroGuide.json
+++ b/GyroGuide.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "IGT",
   "scm_revision": "master",
-  "scm_url": "https://github.com/lpfang/GyroGuide.git"
+  "scm_url": "https://github.com/lpfang/GyroGuide.git",
+  "tier": 3
 }

--- a/HDBrainExtraction.json
+++ b/HDBrainExtraction.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": ["PyTorch"],
   "build_subdirectory": ".",
   "category": "Segmentation",
   "scm_revision": "main",
-  "scm_url": "https://github.com/lassoan/SlicerHDBrainExtraction.git"
+  "scm_url": "https://github.com/lassoan/SlicerHDBrainExtraction.git",
+  "tier": 3
 }

--- a/IDCBrowser.json
+++ b/IDCBrowser.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": ["QuantitativeReporting"],
   "build_subdirectory": ".",
   "category": "Informatics",
   "scm_revision": "main",
-  "scm_url": "https://github.com/ImagingDataCommons/SlicerIDCBrowser.git"
+  "scm_url": "https://github.com/ImagingDataCommons/SlicerIDCBrowser.git",
+  "tier": 3
 }

--- a/ImageAugmenter.json
+++ b/ImageAugmenter.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Utilities",
   "scm_revision": "main",
-  "scm_url": "https://github.com/ciroraggio/SlicerImageAugmenter.git"
+  "scm_url": "https://github.com/ciroraggio/SlicerImageAugmenter.git",
+  "tier": 3
 }

--- a/ImageCompare.json
+++ b/ImageCompare.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Quantification",
   "scm_revision": "master",
-  "scm_url": "https://github.com/pzaffino/SlicerImageCompare.git"
+  "scm_url": "https://github.com/pzaffino/SlicerImageCompare.git",
+  "tier": 3
 }

--- a/ImageMaker.json
+++ b/ImageMaker.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Developer Tools",
   "scm_revision": "master",
-  "scm_url": "https://github.com/finetjul/ImageMaker"
+  "scm_url": "https://github.com/finetjul/ImageMaker",
+  "tier": 3
 }

--- a/IntensitySegmenter.json
+++ b/IntensitySegmenter.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Segmentation",
   "scm_revision": "release",
-  "scm_url": "https://github.com/DCBIA-OrthoLab/IntensitySegmenter.git"
+  "scm_url": "https://github.com/DCBIA-OrthoLab/IntensitySegmenter.git",
+  "tier": 1
 }

--- a/KidneyStoneCalculator.json
+++ b/KidneyStoneCalculator.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Segmentation",
   "scm_revision": "master",
-  "scm_url": "https://github.com/fredericpanthier/SlicerKidneyStoneCalculator.git"
+  "scm_url": "https://github.com/fredericpanthier/SlicerKidneyStoneCalculator.git",
+  "tier": 3
 }

--- a/LanguagePacks.json
+++ b/LanguagePacks.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Utilities",
   "scm_revision": "main",
-  "scm_url": "https://github.com/Slicer/SlicerLanguagePacks"
+  "scm_url": "https://github.com/Slicer/SlicerLanguagePacks",
+  "tier": 5
 }

--- a/LesionSimulator.json
+++ b/LesionSimulator.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Simulation",
   "scm_revision": "main",
-  "scm_url": "https://github.com/CSIM-Toolkits/Slicer-LesionSimulatorExtension.git"
+  "scm_url": "https://github.com/CSIM-Toolkits/Slicer-LesionSimulatorExtension.git",
+  "tier": 3
 }

--- a/LesionSpotlight.json
+++ b/LesionSpotlight.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": ["AnomalousFiltersExtension"],
   "build_subdirectory": ".",
   "category": "Segmentation",
   "scm_revision": "main",
-  "scm_url": "https://github.com/CSIM-Toolkits/Slicer-LesionSpotlightExtension.git"
+  "scm_url": "https://github.com/CSIM-Toolkits/Slicer-LesionSpotlightExtension.git",
+  "tier": 3
 }

--- a/LungCTAnalyzer.json
+++ b/LungCTAnalyzer.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [
     "PyTorch",
     "SegmentEditorExtraEffects",
@@ -8,5 +8,6 @@
   "build_subdirectory": ".",
   "category": "Chest Imaging Platform",
   "scm_revision": "master",
-  "scm_url": "https://github.com/Slicer/SlicerLungCTAnalyzer"
+  "scm_url": "https://github.com/Slicer/SlicerLungCTAnalyzer",
+  "tier": 3
 }

--- a/MEMOS.json
+++ b/MEMOS.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": ["PyTorch"],
   "build_subdirectory": ".",
   "category": "Segmentation",
   "scm_revision": "main",
-  "scm_url": "https://github.com/SlicerMorph/SlicerMEMOS"
+  "scm_url": "https://github.com/SlicerMorph/SlicerMEMOS",
+  "tier": 3
 }

--- a/MHubRunner.json
+++ b/MHubRunner.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Examples",
   "scm_revision": "main",
-  "scm_url": "https://github.com/MHubAI/SlicerMRunner"
+  "scm_url": "https://github.com/MHubAI/SlicerMRunner",
+  "tier": 3
 }

--- a/MONAIAuto3DSeg.json
+++ b/MONAIAuto3DSeg.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": ["PyTorch"],
   "build_subdirectory": ".",
   "category": "Segmentation",
   "scm_revision": "main",
-  "scm_url": "https://github.com/lassoan/SlicerMONAIAuto3DSeg"
+  "scm_url": "https://github.com/lassoan/SlicerMONAIAuto3DSeg",
+  "tier": 5
 }

--- a/MONAILabel.json
+++ b/MONAILabel.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Active Learning",
   "scm_revision": "main",
-  "scm_url": "https://github.com/Project-MONAI/MONAILabel.git"
+  "scm_url": "https://github.com/Project-MONAI/MONAILabel.git",
+  "tier": 3
 }

--- a/MONAIViz.json
+++ b/MONAIViz.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": ["PyTorch"],
   "build_subdirectory": ".",
   "category": "Developer Tools",
   "scm_revision": "main",
-  "scm_url": "https://github.com/Project-MONAI/SlicerMONAIViz"
+  "scm_url": "https://github.com/Project-MONAI/SlicerMONAIViz",
+  "tier": 3
 }

--- a/MRUSLandmarking.json
+++ b/MRUSLandmarking.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Informatics",
   "scm_revision": "main",
-  "scm_url": "https://github.com/koegl/SlicerMRUSLandmarking.git"
+  "scm_url": "https://github.com/koegl/SlicerMRUSLandmarking.git",
+  "tier": 3
 }

--- a/MarkupsToModel.json
+++ b/MarkupsToModel.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Informatics",
   "scm_revision": "master",
-  "scm_url": "https://github.com/SlicerIGT/SlicerMarkupsToModel"
+  "scm_url": "https://github.com/SlicerIGT/SlicerMarkupsToModel",
+  "tier": 5
 }

--- a/MassVision.json
+++ b/MassVision.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Spectral Imaging",
   "scm_revision": "main",
-  "scm_url": "https://github.com/jamzad/SlicerMassVision"
+  "scm_url": "https://github.com/jamzad/SlicerMassVision",
+  "tier": 3
 }

--- a/MatlabBridge.json
+++ b/MatlabBridge.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": ["SlicerOpenIGTLink"],
   "build_subdirectory": ".",
   "category": "Developer Tools",
   "scm_revision": "master",
-  "scm_url": "https://github.com/PerkLab/SlicerMatlabBridge.git"
+  "scm_url": "https://github.com/PerkLab/SlicerMatlabBridge.git",
+  "tier": 3
 }

--- a/MedialSkeleton.json
+++ b/MedialSkeleton.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": "inner-build",
   "category": "Shape Analysis",
   "scm_revision": "main",
-  "scm_url": "https://github.com/JolleyLab/SlicerMedialSkeleton.git"
+  "scm_url": "https://github.com/JolleyLab/SlicerMedialSkeleton.git",
+  "tier": 3
 }

--- a/MeshStatisticsExtension.json
+++ b/MeshStatisticsExtension.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": ["ModelToModelDistance"],
   "build_subdirectory": ".",
   "category": "Shape Analysis",
   "scm_revision": "master",
-  "scm_url": "https://github.com/DCBIA-OrthoLab/MeshStatisticsExtension.git"
+  "scm_url": "https://github.com/DCBIA-OrthoLab/MeshStatisticsExtension.git",
+  "tier": 3
 }

--- a/MeshToLabelMap.json
+++ b/MeshToLabelMap.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Shape Analysis",
   "scm_revision": "master",
-  "scm_url": "https://github.com/NIRALUser/MeshToLabelMap.git"
+  "scm_url": "https://github.com/NIRALUser/MeshToLabelMap.git",
+  "tier": 1
 }

--- a/ModelClip.json
+++ b/ModelClip.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Surface Models",
   "scm_revision": "main",
-  "scm_url": "https://github.com/jamesobutler/ModelClip.git"
+  "scm_url": "https://github.com/jamesobutler/ModelClip.git",
+  "tier": 1
 }

--- a/ModelCropper.json
+++ b/ModelCropper.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Surface Models",
   "scm_revision": "master",
-  "scm_url": "https://github.com/sebastianandress/Slicer-ModelCropper.git"
+  "scm_url": "https://github.com/sebastianandress/Slicer-ModelCropper.git",
+  "tier": 3
 }

--- a/ModelToModelDistance.json
+++ b/ModelToModelDistance.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Quantification",
   "scm_revision": "master",
-  "scm_url": "https://github.com/NIRALUser/3DMetricTools.git"
+  "scm_url": "https://github.com/NIRALUser/3DMetricTools.git",
+  "tier": 3
 }

--- a/NNUNet.json
+++ b/NNUNet.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": ["PyTorch", "SlicerPythonTestRunner"],
   "build_subdirectory": ".",
   "category": "Segmentation",
   "scm_revision": "main",
-  "scm_url": "https://github.com/KitwareMedical/SlicerNNUnet"
+  "scm_url": "https://github.com/KitwareMedical/SlicerNNUnet",
+  "tier": 5
 }

--- a/NeedleFinder.json
+++ b/NeedleFinder.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "IGT",
   "scm_revision": "master",
-  "scm_url": "https://github.com/needlefinder/NeedleFinder.git"
+  "scm_url": "https://github.com/needlefinder/NeedleFinder.git",
+  "tier": 1
 }

--- a/NvidiaAIAssistedAnnotation.json
+++ b/NvidiaAIAssistedAnnotation.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Segmentation",
   "scm_revision": "master",
-  "scm_url": "https://github.com/NVIDIA/ai-assisted-annotation-client.git"
+  "scm_url": "https://github.com/NVIDIA/ai-assisted-annotation-client.git",
+  "tier": 1
 }

--- a/OpenDose3D.json
+++ b/OpenDose3D.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": ["SlicerElastix"],
   "build_subdirectory": ".",
   "category": "Radiotherapy",
   "scm_revision": "master-stable",
-  "scm_url": "https://gitlab.com/opendose/opendose3d.git"
+  "scm_url": "https://gitlab.com/opendose/opendose3d.git",
+  "tier": 3
 }

--- a/OrthodonticAnalysis.json
+++ b/OrthodonticAnalysis.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Orthodontics",
   "scm_revision": "master",
-  "scm_url": "https://github.com/OrthodonticAnalysis/SlicerOrthodonticAnalysis"
+  "scm_url": "https://github.com/OrthodonticAnalysis/SlicerOrthodonticAnalysis",
+  "tier": 1
 }

--- a/OsteotomyPlanner.json
+++ b/OsteotomyPlanner.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Osteotomy Planning",
   "scm_revision": "master",
-  "scm_url": "https://github.com/KitwareMedical/OsteotomyPlanner.git"
+  "scm_url": "https://github.com/KitwareMedical/OsteotomyPlanner.git",
+  "tier": 3
 }

--- a/PBNRR.json
+++ b/PBNRR.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": "inner-build",
   "category": "Registration",
   "scm_revision": "master",
-  "scm_url": "https://github.com/aangelos28/PBNRR.git"
+  "scm_url": "https://github.com/aangelos28/PBNRR.git",
+  "tier": 3
 }

--- a/PET-IndiC.json
+++ b/PET-IndiC.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Quantification",
   "scm_revision": "master",
-  "scm_url": "https://github.com/QIICR/PET-IndiC.git"
+  "scm_url": "https://github.com/QIICR/PET-IndiC.git",
+  "tier": 3
 }

--- a/PET-MUST-Segmenter.json
+++ b/PET-MUST-Segmenter.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": ["SlicerRadiomics"],
   "build_subdirectory": ".",
   "category": "Segmentation",
   "scm_revision": "master",
-  "scm_url": "https://github.com/kyliekeijzer/Slicer-PET-MUST-segmenter.git"
+  "scm_url": "https://github.com/kyliekeijzer/Slicer-PET-MUST-segmenter.git",
+  "tier": 3
 }

--- a/PETCPhantom.json
+++ b/PETCPhantom.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Quantification",
   "scm_revision": "master",
-  "scm_url": "https://github.com/QIICR/SlicerPETPhantomAnalysis.git"
+  "scm_url": "https://github.com/QIICR/SlicerPETPhantomAnalysis.git",
+  "tier": 3
 }

--- a/PETDICOMExtension.json
+++ b/PETDICOMExtension.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Converters",
   "scm_revision": "master",
-  "scm_url": "https://github.com/QIICR/Slicer-PETDICOMExtension.git"
+  "scm_url": "https://github.com/QIICR/Slicer-PETDICOMExtension.git",
+  "tier": 3
 }

--- a/PETLiverUptakeMeasurement.json
+++ b/PETLiverUptakeMeasurement.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": ["DCMQI"],
   "build_subdirectory": ".",
   "category": "Quantification",
   "scm_revision": "master",
-  "scm_url": "https://github.com/QIICR/PETLiverUptakeMeasurement"
+  "scm_url": "https://github.com/QIICR/PETLiverUptakeMeasurement",
+  "tier": 3
 }

--- a/PETTumorSegmentation.json
+++ b/PETTumorSegmentation.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Segmentation",
   "scm_revision": "master",
-  "scm_url": "https://github.com/QIICR/PETTumorSegmentation.git"
+  "scm_url": "https://github.com/QIICR/PETTumorSegmentation.git",
+  "tier": 3
 }

--- a/ParallelProcessing.json
+++ b/ParallelProcessing.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Utilities",
   "scm_revision": "master",
-  "scm_url": "https://github.com/pieper/SlicerParallelProcessing"
+  "scm_url": "https://github.com/pieper/SlicerParallelProcessing",
+  "tier": 5
 }

--- a/PathReconstruction.json
+++ b/PathReconstruction.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": ["MarkupsToModel", "SlicerIGT", "SlicerRT"],
   "build_subdirectory": ".",
   "category": "IGT",
   "scm_revision": "master",
-  "scm_url": "https://github.com/SlicerIGT/SlicerPathReconstruction.git"
+  "scm_url": "https://github.com/SlicerIGT/SlicerPathReconstruction.git",
+  "tier": 3
 }

--- a/PedicleScrewSimulator.json
+++ b/PedicleScrewSimulator.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Training",
   "scm_revision": "master",
-  "scm_url": "https://github.com/lassoan/PedicleScrewSimulator"
+  "scm_url": "https://github.com/lassoan/PedicleScrewSimulator",
+  "tier": 3
 }

--- a/PercutaneousApproachAnalysis.json
+++ b/PercutaneousApproachAnalysis.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "IGT",
   "scm_revision": "master",
-  "scm_url": "https://github.com/SlicerIGT/PercutaneousApproachAnalysis"
+  "scm_url": "https://github.com/SlicerIGT/PercutaneousApproachAnalysis",
+  "tier": 3
 }

--- a/PerkTutor.json
+++ b/PerkTutor.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Training",
   "scm_revision": "master",
-  "scm_url": "https://github.com/PerkTutor/PerkTutor.git"
+  "scm_url": "https://github.com/PerkTutor/PerkTutor.git",
+  "tier": 3
 }

--- a/PetSpectAnalysis.json
+++ b/PetSpectAnalysis.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Nuclear Medicine",
   "scm_revision": "master",
-  "scm_url": "https://github.com/gti-fing/SlicerPetSpectAnalysis.git"
+  "scm_url": "https://github.com/gti-fing/SlicerPetSpectAnalysis.git",
+  "tier": 3
 }

--- a/PickAndPaintExtension.json
+++ b/PickAndPaintExtension.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Shape Analysis",
   "scm_revision": "master",
-  "scm_url": "https://github.com/DCBIA-OrthoLab/PickAndPaintExtension.git"
+  "scm_url": "https://github.com/DCBIA-OrthoLab/PickAndPaintExtension.git",
+  "tier": 3
 }

--- a/Pipelines.json
+++ b/Pipelines.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Pipelines",
   "scm_revision": "main",
-  "scm_url": "https://github.com/KitwareMedical/SlicerPipelines.git"
+  "scm_url": "https://github.com/KitwareMedical/SlicerPipelines.git",
+  "tier": 3
 }

--- a/PkModeling.json
+++ b/PkModeling.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": "pkmodeling-build",
   "category": "Quantification",
   "scm_revision": "master",
-  "scm_url": "https://github.com/QIICR/PkModeling.git"
+  "scm_url": "https://github.com/QIICR/PkModeling.git",
+  "tier": 3
 }

--- a/PortPlacement.json
+++ b/PortPlacement.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": "inner-build",
   "category": "IGT",
   "scm_revision": "master",
-  "scm_url": "https://github.com/SlicerIGT/PortPlacement.git"
+  "scm_url": "https://github.com/SlicerIGT/PortPlacement.git",
+  "tier": 3
 }

--- a/PyTorch.json
+++ b/PyTorch.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Utilities",
   "scm_revision": "main",
-  "scm_url": "https://github.com/fepegar/SlicerPyTorch.git"
+  "scm_url": "https://github.com/fepegar/SlicerPyTorch.git",
+  "tier": 5
 }

--- a/Q3DC.json
+++ b/Q3DC.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": ["SlicerMarkupConstraints"],
   "build_subdirectory": ".",
   "category": "Shape Analysis",
   "scm_revision": "master",
-  "scm_url": "https://github.com/DCBIA-OrthoLab/Q3DCExtension.git"
+  "scm_url": "https://github.com/DCBIA-OrthoLab/Q3DCExtension.git",
+  "tier": 3
 }

--- a/QuantitativeReporting.json
+++ b/QuantitativeReporting.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [
     "SlicerDevelopmentToolbox",
     "DCMQI",
@@ -8,5 +8,6 @@
   "build_subdirectory": ".",
   "category": "Informatics",
   "scm_revision": "master",
-  "scm_url": "https://github.com/QIICR/QuantitativeReporting.git"
+  "scm_url": "https://github.com/QIICR/QuantitativeReporting.git",
+  "tier": 5
 }

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
-Slicer Extensions Index
-=======================
+# Slicer Extensions Index
 
-Overview
---------
+## Overview
 
 Think of the ExtensionsIndex as a repository containing a list of [extension description file][]s
 (*.s4ext) used by the Slicer extensions build system to build, test, package and upload
@@ -17,21 +15,27 @@ slicer factory interact.
 
 <img width="80%" src="https://www.slicer.org/slicerWiki/images/a/ab/Extensions-Index-to-Catalog-cycle.png"/>
 
-Build instructions
-------------------
+## Extension tiers
+
+We accept extensions to 3D Slicer at various quality and maturity levels. To make it clear for users what they can expect from a particular extension, 3D Slicer maintainers assign each extension to a "tier":
+
+- Tier 1: Experimental extensions.
+- Tier 3: Community-supported extensions.
+- Tier 5: Critically important extensions, supported by Slicer core developers.
+
+Extension tier 2 and 4 are reserved for future use, to allow defining intermediate steps between the initially defined tiers without reclassifying every extension.
+
+## Build instructions
 
 See https://slicer.readthedocs.io/en/latest/developer_guide/extensions.html#extensions-build-system
 
-Contact
--------
+## Contact
 
 Questions regarding this project should be posted on 3D Slicer forum: https://discourse.slicer.org
 
-License
--------
+## License
 
 * [3D Slicer license](https://github.com/Slicer/Slicer/blob/main/License.txt)
-
 
 [CDash]: https://slicer.cdash.org/index.php?project=SlicerPreview
 [extensions manager]: https://slicer.readthedocs.io/en/latest/user_guide/extensions_manager.html

--- a/RVXLiverSegmentation.json
+++ b/RVXLiverSegmentation.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [
     "SlicerVMTK",
     "MarkupsToModel",
@@ -9,5 +9,6 @@
   "build_subdirectory": ".",
   "category": "Segmentation",
   "scm_revision": "main",
-  "scm_url": "https://github.com/R-Vessel-X/SlicerRVXLiverSegmentation"
+  "scm_url": "https://github.com/R-Vessel-X/SlicerRVXLiverSegmentation",
+  "tier": 3
 }

--- a/RVXVesselnessFilters.json
+++ b/RVXVesselnessFilters.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Filtering.Vesselness",
   "scm_revision": "main",
-  "scm_url": "https://github.com/R-Vessel-X/SlicerRVXVesselnessFilters"
+  "scm_url": "https://github.com/R-Vessel-X/SlicerRVXVesselnessFilters",
+  "tier": 3
 }

--- a/RawImageGuess.json
+++ b/RawImageGuess.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Informatics",
   "scm_revision": "master",
-  "scm_url": "https://github.com/acetylsalicyl/SlicerRawImageGuess"
+  "scm_url": "https://github.com/acetylsalicyl/SlicerRawImageGuess",
+  "tier": 3
 }

--- a/RegistrationQA.json
+++ b/RegistrationQA.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": ["SlicerRT"],
   "build_subdirectory": ".",
   "category": "Registration",
   "scm_revision": "master",
-  "scm_url": "https://github.com/gsi-biomotion/SlicerRegistrationQA.git"
+  "scm_url": "https://github.com/gsi-biomotion/SlicerRegistrationQA.git",
+  "tier": 3
 }

--- a/RegularizedFastMarching.json
+++ b/RegularizedFastMarching.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Segmentation",
   "scm_revision": "main",
-  "scm_url": "https://github.com/jamesobutler/SlicerRegularizedFastMarching"
+  "scm_url": "https://github.com/jamesobutler/SlicerRegularizedFastMarching",
+  "tier": 1
 }

--- a/ResectionPlanner.json
+++ b/ResectionPlanner.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": ["SlicerRT"],
   "build_subdirectory": ".",
   "category": "IGT",
   "scm_revision": "master",
-  "scm_url": "https://github.com/SlicerIGT/ResectionPlanner.git"
+  "scm_url": "https://github.com/SlicerIGT/ResectionPlanner.git",
+  "tier": 1
 }

--- a/SNRMeasurement.json
+++ b/SNRMeasurement.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "IGT",
   "scm_revision": "master",
-  "scm_url": "https://github.com/SNRLab/SNRMeasurement"
+  "scm_url": "https://github.com/SNRLab/SNRMeasurement",
+  "tier": 3
 }

--- a/SPHARM-PDM.json
+++ b/SPHARM-PDM.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": ["MeshToLabelMap"],
   "build_subdirectory": "SPHARM-PDM-build",
   "category": "SPHARM",
   "scm_revision": "master",
-  "scm_url": "https://github.com/NIRALUser/SPHARM-PDM.git"
+  "scm_url": "https://github.com/NIRALUser/SPHARM-PDM.git",
+  "tier": 3
 }

--- a/Sandbox.json
+++ b/Sandbox.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Examples",
   "scm_revision": "master",
-  "scm_url": "https://github.com/PerkLab/SlicerSandbox.git"
+  "scm_url": "https://github.com/PerkLab/SlicerSandbox.git",
+  "tier": 3
 }

--- a/ScatteredTransform.json
+++ b/ScatteredTransform.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Registration",
   "scm_revision": "master",
-  "scm_url": "https://github.com/Sunderlandkyl/ScatteredTransform"
+  "scm_url": "https://github.com/Sunderlandkyl/ScatteredTransform",
+  "tier": 3
 }

--- a/Scoliosis.json
+++ b/Scoliosis.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Quantification",
   "scm_revision": "master",
-  "scm_url": "https://github.com/SlicerIGT/Scoliosis.git"
+  "scm_url": "https://github.com/SlicerIGT/Scoliosis.git",
+  "tier": 1
 }

--- a/ScriptEditor.json
+++ b/ScriptEditor.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Developer Tools",
   "scm_revision": "main",
-  "scm_url": "https://github.com/SlicerMorph/SlicerScriptEditor"
+  "scm_url": "https://github.com/SlicerMorph/SlicerScriptEditor",
+  "tier": 3
 }

--- a/SegmentEditorExtraEffects.json
+++ b/SegmentEditorExtraEffects.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": ["MarkupsToModel"],
   "build_subdirectory": ".",
   "category": "Segmentation",
   "scm_revision": "master",
-  "scm_url": "https://github.com/lassoan/SlicerSegmentEditorExtraEffects"
+  "scm_url": "https://github.com/lassoan/SlicerSegmentEditorExtraEffects",
+  "tier": 5
 }

--- a/SegmentMesher.json
+++ b/SegmentMesher.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": "inner-build",
   "category": "Segmentation",
   "scm_revision": "master",
-  "scm_url": "https://github.com/lassoan/SlicerSegmentMesher.git"
+  "scm_url": "https://github.com/lassoan/SlicerSegmentMesher.git",
+  "tier": 5
 }

--- a/SegmentRegistration.json
+++ b/SegmentRegistration.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": ["SlicerProstate", "SlicerRT"],
   "build_subdirectory": ".",
   "category": "Registration",
   "scm_revision": "master",
-  "scm_url": "https://github.com/SlicerRt/SegmentRegistration.git"
+  "scm_url": "https://github.com/SlicerRt/SegmentRegistration.git",
+  "tier": 3
 }

--- a/SegmentWithSAM.json
+++ b/SegmentWithSAM.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": ["PyTorch"],
   "build_subdirectory": ".",
   "category": "Segmentation",
   "scm_revision": "main",
-  "scm_url": "https://github.com/mazurowski-lab/SlicerSegmentWithSAM"
+  "scm_url": "https://github.com/mazurowski-lab/SlicerSegmentWithSAM",
+  "tier": 3
 }

--- a/SegmentationAidedRegistration.json
+++ b/SegmentationAidedRegistration.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Registration",
   "scm_revision": "master",
-  "scm_url": "https://github.com/gaoyi/SegmentationAidedRegistration.git"
+  "scm_url": "https://github.com/gaoyi/SegmentationAidedRegistration.git",
+  "tier": 1
 }

--- a/SegmentationReview.json
+++ b/SegmentationReview.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Segmentation",
   "scm_revision": "main",
-  "scm_url": "https://github.com/zapaishchykova/SegmentationReview"
+  "scm_url": "https://github.com/zapaishchykova/SegmentationReview",
+  "tier": 3
 }

--- a/SegmentationVerification.json
+++ b/SegmentationVerification.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Segmentation",
   "scm_revision": "main",
-  "scm_url": "https://github.com/cpinter/SlicerSegmentationVerification.git"
+  "scm_url": "https://github.com/cpinter/SlicerSegmentationVerification.git",
+  "tier": 3
 }

--- a/SequenceRegistration.json
+++ b/SequenceRegistration.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": ["SlicerElastix"],
   "build_subdirectory": ".",
   "category": "Sequences",
   "scm_revision": "master",
-  "scm_url": "https://github.com/moselhy/SlicerSequenceRegistration"
+  "scm_url": "https://github.com/moselhy/SlicerSequenceRegistration",
+  "tier": 5
 }

--- a/ShapePopulationViewer.json
+++ b/ShapePopulationViewer.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Shape Visualization",
   "scm_revision": "master",
-  "scm_url": "https://github.com/NIRALUser/ShapePopulationViewer.git"
+  "scm_url": "https://github.com/NIRALUser/ShapePopulationViewer.git",
+  "tier": 3
 }

--- a/ShapeRegressionExtension.json
+++ b/ShapeRegressionExtension.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": "ShapeRegressionExtension-build",
   "category": "Shape Regression",
   "scm_revision": "master",
-  "scm_url": "https://github.com/KitwareMedical/ShapeRegressionExtension.git"
+  "scm_url": "https://github.com/KitwareMedical/ShapeRegressionExtension.git",
+  "tier": 3
 }

--- a/ShapeVariationAnalyzer.json
+++ b/ShapeVariationAnalyzer.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": ["ShapePopulationViewer"],
   "build_subdirectory": "inner-build",
   "category": "Quantification",
   "scm_revision": "master",
-  "scm_url": "https://github.com/DCBIA-OrthoLab/ShapeVariationAnalyzer.git"
+  "scm_url": "https://github.com/DCBIA-OrthoLab/ShapeVariationAnalyzer.git",
+  "tier": 3
 }

--- a/SkeletalRepresentation.json
+++ b/SkeletalRepresentation.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": "inner-build",
   "category": "Shape Analysis",
   "scm_revision": "master",
-  "scm_url": "https://github.com/KitwareMedical/SlicerSkeletalRepresentation.git"
+  "scm_url": "https://github.com/KitwareMedical/SlicerSkeletalRepresentation.git",
+  "tier": 3
 }

--- a/SkinMouldGenerator.json
+++ b/SkinMouldGenerator.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Radiotherapy",
   "scm_revision": "master",
-  "scm_url": "https://github.com/PerkLab/SlicerSkinMouldGenerator.git"
+  "scm_url": "https://github.com/PerkLab/SlicerSkinMouldGenerator.git",
+  "tier": 3
 }

--- a/SkullStripper.json
+++ b/SkullStripper.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Segmentation",
   "scm_revision": "master",
-  "scm_url": "https://github.com/Slicer/SkullStripper.git"
+  "scm_url": "https://github.com/Slicer/SkullStripper.git",
+  "tier": 3
 }

--- a/SlicerAIGT.json
+++ b/SlicerAIGT.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": ["SlicerOpenIGTLink", "SlicerIGT"],
   "build_subdirectory": ".",
   "category": "IGT",
   "scm_revision": "master",
-  "scm_url": "https://github.com/SlicerIGT/aigt.git"
+  "scm_url": "https://github.com/SlicerIGT/aigt.git",
+  "tier": 1
 }

--- a/SlicerANTs.json
+++ b/SlicerANTs.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": "inner-build",
   "category": "Registration",
   "scm_revision": "master",
-  "scm_url": "https://github.com/netstim/SlicerANTs.git"
+  "scm_url": "https://github.com/netstim/SlicerANTs.git",
+  "tier": 3
 }

--- a/SlicerAutoscoperM.json
+++ b/SlicerAutoscoperM.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": ["Sandbox", "SegmentEditorExtraEffects"],
   "build_subdirectory": "inner-build",
   "category": "Tracking",
   "scm_revision": "main",
-  "scm_url": "https://github.com/BrownBiomechanics/SlicerAutoscoperM.git"
+  "scm_url": "https://github.com/BrownBiomechanics/SlicerAutoscoperM.git",
+  "tier": 3
 }

--- a/SlicerBatchAnonymize.json
+++ b/SlicerBatchAnonymize.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "DSCI",
   "scm_revision": "main",
-  "scm_url": "https://github.com/hina-shah/SlicerBatchAnonymize.git"
+  "scm_url": "https://github.com/hina-shah/SlicerBatchAnonymize.git",
+  "tier": 3
 }

--- a/SlicerBiomech.json
+++ b/SlicerBiomech.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": ["SlicerMorph"],
   "build_subdirectory": ".",
   "category": "Quantification",
   "scm_revision": "main",
-  "scm_url": "https://github.com/jmhuie/SlicerBiomech.git"
+  "scm_url": "https://github.com/jmhuie/SlicerBiomech.git",
+  "tier": 3
 }

--- a/SlicerCMF.json
+++ b/SlicerCMF.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [
     "AnglePlanesExtension",
     "BoneTextureExtension",
@@ -18,5 +18,6 @@
   "build_subdirectory": ".",
   "category": "SlicerCMF",
   "scm_revision": "master",
-  "scm_url": "https://github.com/DCBIA-OrthoLab/SlicerCMF.git"
+  "scm_url": "https://github.com/DCBIA-OrthoLab/SlicerCMF.git",
+  "tier": 3
 }

--- a/SlicerCaseIterator.json
+++ b/SlicerCaseIterator.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": ["SlicerDevelopmentToolbox"],
   "build_subdirectory": ".",
   "category": "Utilities",
   "scm_revision": "master",
-  "scm_url": "https://github.com/JoostJM/SlicerCaseIterator.git"
+  "scm_url": "https://github.com/JoostJM/SlicerCaseIterator.git",
+  "tier": 3
 }

--- a/SlicerCervicalSpine.json
+++ b/SlicerCervicalSpine.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": ["SlicerCochlea"],
   "build_subdirectory": ".",
   "category": "VisSimTools",
   "scm_revision": "master",
-  "scm_url": "https://github.com/MedicalImageAnalysisTutorials/SlicerCervicalSpine"
+  "scm_url": "https://github.com/MedicalImageAnalysisTutorials/SlicerCervicalSpine",
+  "tier": 3
 }

--- a/SlicerCineTrack.json
+++ b/SlicerCineTrack.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Sequences",
   "scm_revision": "main",
-  "scm_url": "https://github.com/laboratory-for-translational-medicine/SlicerCineTrack"
+  "scm_url": "https://github.com/laboratory-for-translational-medicine/SlicerCineTrack",
+  "tier": 3
 }

--- a/SlicerCochlea.json
+++ b/SlicerCochlea.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": ["SlicerElastix"],
   "build_subdirectory": ".",
   "category": "VisSimTools",
   "scm_revision": "master",
-  "scm_url": "https://github.com/MedicalImageAnalysisTutorials/SlicerCochlea"
+  "scm_url": "https://github.com/MedicalImageAnalysisTutorials/SlicerCochlea",
+  "tier": 3
 }

--- a/SlicerConda.json
+++ b/SlicerConda.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Conda",
   "scm_revision": "main",
-  "scm_url": "https://github.com/DCBIA-OrthoLab/SlicerConda.git"
+  "scm_url": "https://github.com/DCBIA-OrthoLab/SlicerConda.git",
+  "tier": 1
 }

--- a/SlicerDMRI.json
+++ b/SlicerDMRI.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": ["UKFTractography"],
   "build_subdirectory": "inner-build",
   "category": "Diffusion",
   "scm_revision": "master",
-  "scm_url": "https://github.com/SlicerDMRI/SlicerDMRI.git"
+  "scm_url": "https://github.com/SlicerDMRI/SlicerDMRI.git",
+  "tier": 5
 }

--- a/SlicerDTIALPS.json
+++ b/SlicerDTIALPS.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Diffusion",
   "scm_revision": "main",
-  "scm_url": "https://github.com/LOAMRI/Slicer-DTI-ALPS.git"
+  "scm_url": "https://github.com/LOAMRI/Slicer-DTI-ALPS.git",
+  "tier": 3
 }

--- a/SlicerDcm2nii.json
+++ b/SlicerDcm2nii.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": "inner-build",
   "category": "Diffusion",
   "scm_revision": "master",
-  "scm_url": "https://github.com/SlicerDMRI/SlicerDcm2nii.git"
+  "scm_url": "https://github.com/SlicerDMRI/SlicerDcm2nii.git",
+  "tier": 5
 }

--- a/SlicerDentalModelSeg.json
+++ b/SlicerDentalModelSeg.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Segmentation",
   "scm_revision": "main",
-  "scm_url": "https://github.com/DCBIA-OrthoLab/SlicerDentalModelSeg.git"
+  "scm_url": "https://github.com/DCBIA-OrthoLab/SlicerDentalModelSeg.git",
+  "tier": 1
 }

--- a/SlicerDevelopmentToolbox.json
+++ b/SlicerDevelopmentToolbox.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Developer Tools",
   "scm_revision": "master",
-  "scm_url": "https://github.com/QIICR/SlicerDevelopmentToolbox.git"
+  "scm_url": "https://github.com/QIICR/SlicerDevelopmentToolbox.git",
+  "tier": 3
 }

--- a/SlicerDiffusionComplexityMap.json
+++ b/SlicerDiffusionComplexityMap.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Diffusion",
   "scm_revision": "main",
-  "scm_url": "https://github.com/CSIM-Toolkits/SlicerDiffusionComplexityMap.git"
+  "scm_url": "https://github.com/CSIM-Toolkits/SlicerDiffusionComplexityMap.git",
+  "tier": 3
 }

--- a/SlicerElastix.json
+++ b/SlicerElastix.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": "inner-build",
   "category": "Registration",
   "scm_revision": "master",
-  "scm_url": "https://github.com/lassoan/SlicerElastix.git"
+  "scm_url": "https://github.com/lassoan/SlicerElastix.git",
+  "tier": 5
 }

--- a/SlicerFab.json
+++ b/SlicerFab.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Printing",
   "scm_revision": "master",
-  "scm_url": "https://github.com/SlicerFab/SlicerFab"
+  "scm_url": "https://github.com/SlicerFab/SlicerFab",
+  "tier": 3
 }

--- a/SlicerFreeSurfer.json
+++ b/SlicerFreeSurfer.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Neuroimaging",
   "scm_revision": "master",
-  "scm_url": "https://github.com/PerkLab/SlicerFreeSurfer.git"
+  "scm_url": "https://github.com/PerkLab/SlicerFreeSurfer.git",
+  "tier": 5
 }

--- a/SlicerHeart.json
+++ b/SlicerHeart.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": ["SlicerIGT"],
   "build_subdirectory": "inner-build",
   "category": "Cardiac",
   "scm_revision": "master",
-  "scm_url": "https://github.com/SlicerHeart/SlicerHeart.git"
+  "scm_url": "https://github.com/SlicerHeart/SlicerHeart.git",
+  "tier": 5
 }

--- a/SlicerIGSIO.json
+++ b/SlicerIGSIO.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": "inner-build",
   "category": "IGT",
   "scm_revision": "master",
-  "scm_url": "https://github.com/IGSIO/SlicerIGSIO.git"
+  "scm_url": "https://github.com/IGSIO/SlicerIGSIO.git",
+  "tier": 5
 }

--- a/SlicerIGT.json
+++ b/SlicerIGT.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": ["SlicerIGSIO"],
   "build_subdirectory": ".",
   "category": "IGT",
   "scm_revision": "master",
-  "scm_url": "https://github.com/SlicerIGT/SlicerIGT.git"
+  "scm_url": "https://github.com/SlicerIGT/SlicerIGT.git",
+  "tier": 5
 }

--- a/SlicerITKUltrasound.json
+++ b/SlicerITKUltrasound.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": "SlicerITKUltrasound-build",
   "category": "Filtering",
   "scm_revision": "master",
-  "scm_url": "https://github.com/KitwareMedical/SlicerITKUltrasound"
+  "scm_url": "https://github.com/KitwareMedical/SlicerITKUltrasound",
+  "tier": 1
 }

--- a/SlicerJupyter.json
+++ b/SlicerJupyter.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": "inner-build",
   "category": "Developer Tools",
   "scm_revision": "master",
-  "scm_url": "https://github.com/Slicer/SlicerJupyter.git"
+  "scm_url": "https://github.com/Slicer/SlicerJupyter.git",
+  "tier": 3
 }

--- a/SlicerLayoutButtons.json
+++ b/SlicerLayoutButtons.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": ["SlicerDevelopmentToolbox"],
   "build_subdirectory": ".",
   "category": "Informatics",
   "scm_revision": "master",
-  "scm_url": "https://github.com/QIICR/SlicerLayoutButtons.git"
+  "scm_url": "https://github.com/QIICR/SlicerLayoutButtons.git",
+  "tier": 3
 }

--- a/SlicerLiver.json
+++ b/SlicerLiver.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [
     "SlicerVMTK",
     "SegmentEditorExtraEffects",
@@ -8,5 +8,6 @@
   "build_subdirectory": ".",
   "category": "IGT",
   "scm_revision": "master",
-  "scm_url": "https://github.com/ALive-research/Slicer-Liver"
+  "scm_url": "https://github.com/ALive-research/Slicer-Liver",
+  "tier": 3
 }

--- a/SlicerLookingGlass.json
+++ b/SlicerLookingGlass.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": "inner-build",
   "category": "Holographic Display",
   "scm_revision": "master",
-  "scm_url": "https://github.com/KitwareMedical/SlicerLookingGlass.git"
+  "scm_url": "https://github.com/KitwareMedical/SlicerLookingGlass.git",
+  "tier": 1
 }

--- a/SlicerMarkupConstraints.json
+++ b/SlicerMarkupConstraints.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Developer Tools",
   "scm_revision": "main",
-  "scm_url": "https://github.com/KitwareMedical/SlicerMarkupConstraints.git"
+  "scm_url": "https://github.com/KitwareMedical/SlicerMarkupConstraints.git",
+  "tier": 3
 }

--- a/SlicerMorph.json
+++ b/SlicerMorph.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": ["SegmentEditorExtraEffects", "SurfaceMarkup"],
   "build_subdirectory": ".",
   "category": "SlicerMorph",
   "scm_revision": "master",
-  "scm_url": "https://github.com/SlicerMorph/SlicerMorph.git"
+  "scm_url": "https://github.com/SlicerMorph/SlicerMorph.git",
+  "tier": 5
 }

--- a/SlicerNetstim.json
+++ b/SlicerNetstim.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": ["SlicerRT", "MarkupsToModel"],
   "build_subdirectory": ".",
   "category": "Netstim",
   "scm_revision": "master",
-  "scm_url": "https://github.com/netstim/SlicerNetstim.git"
+  "scm_url": "https://github.com/netstim/SlicerNetstim.git",
+  "tier": 3
 }

--- a/SlicerNeuro.json
+++ b/SlicerNeuro.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [
     "UKFTractography",
     "SwissSkullStripper",
@@ -12,5 +12,6 @@
   "build_subdirectory": ".",
   "category": "Neuroimaging",
   "scm_revision": "main",
-  "scm_url": "https://github.com/Slicer/SlicerNeuro"
+  "scm_url": "https://github.com/Slicer/SlicerNeuro",
+  "tier": 5
 }

--- a/SlicerNeuroSegmentation.json
+++ b/SlicerNeuroSegmentation.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": ["SlicerFreeSurfer"],
   "build_subdirectory": ".",
   "category": "Neuroimaging",
   "scm_revision": "main",
-  "scm_url": "https://github.com/HOA-2/SlicerNeuroSegmentation.git"
+  "scm_url": "https://github.com/HOA-2/SlicerNeuroSegmentation.git",
+  "tier": 3
 }

--- a/SlicerOpenAnatomy.json
+++ b/SlicerOpenAnatomy.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Segmentation",
   "scm_revision": "master",
-  "scm_url": "https://github.com/PerkLab/SlicerOpenAnatomy"
+  "scm_url": "https://github.com/PerkLab/SlicerOpenAnatomy",
+  "tier": 5
 }

--- a/SlicerOpenIGTLink.json
+++ b/SlicerOpenIGTLink.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": "inner-build",
   "category": "IGT",
   "scm_revision": "master",
-  "scm_url": "https://github.com/openigtlink/SlicerOpenIGTLink.git"
+  "scm_url": "https://github.com/openigtlink/SlicerOpenIGTLink.git",
+  "tier": 5
 }

--- a/SlicerPRISMRendering.json
+++ b/SlicerPRISMRendering.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Rendering",
   "scm_revision": "master",
-  "scm_url": "https://github.com/ETS-vis-interactive/SlicerPRISMRendering"
+  "scm_url": "https://github.com/ETS-vis-interactive/SlicerPRISMRendering",
+  "tier": 3
 }

--- a/SlicerProstate.json
+++ b/SlicerProstate.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Informatics",
   "scm_revision": "master",
-  "scm_url": "https://github.com/SlicerProstate/SlicerProstate.git"
+  "scm_url": "https://github.com/SlicerProstate/SlicerProstate.git",
+  "tier": 3
 }

--- a/SlicerProstateAblation.json
+++ b/SlicerProstateAblation.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": ["SlicerDevelopmentToolbox", "ZFrameRegistration"],
   "build_subdirectory": ".",
   "category": "IGT",
   "scm_revision": "master",
-  "scm_url": "https://github.com/SlicerProstate/SlicerProstateAblation.git"
+  "scm_url": "https://github.com/SlicerProstate/SlicerProstateAblation.git",
+  "tier": 3
 }

--- a/SlicerPythonTestRunner.json
+++ b/SlicerPythonTestRunner.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Developer Tools",
   "scm_revision": "main",
-  "scm_url": "https://github.com/KitwareMedical/SlicerPythonTestRunner"
+  "scm_url": "https://github.com/KitwareMedical/SlicerPythonTestRunner",
+  "tier": 3
 }

--- a/SlicerRT.json
+++ b/SlicerRT.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": "inner-build",
   "category": "Radiotherapy",
   "scm_revision": "master",
-  "scm_url": "https://github.com/SlicerRt/SlicerRT.git"
+  "scm_url": "https://github.com/SlicerRt/SlicerRT.git",
+  "tier": 5
 }

--- a/SlicerRadiomics.json
+++ b/SlicerRadiomics.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": "inner-build",
   "category": "Informatics",
   "scm_revision": "master",
-  "scm_url": "https://github.com/AIM-Harvard/SlicerRadiomics.git"
+  "scm_url": "https://github.com/AIM-Harvard/SlicerRadiomics.git",
+  "tier": 1
 }

--- a/SlicerThemes.json
+++ b/SlicerThemes.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Developer Tools",
   "scm_revision": "main",
-  "scm_url": "https://github.com/sjh26/SlicerThemes.git"
+  "scm_url": "https://github.com/sjh26/SlicerThemes.git",
+  "tier": 3
 }

--- a/SlicerToKiwiExporter.json
+++ b/SlicerToKiwiExporter.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Exporter",
   "scm_revision": "master",
-  "scm_url": "https://github.com/jcfr/SlicerToKiwiExporter.git"
+  "scm_url": "https://github.com/jcfr/SlicerToKiwiExporter.git",
+  "tier": 1
 }

--- a/SlicerVMTK.json
+++ b/SlicerVMTK.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": ["ExtraMarkups"],
   "build_subdirectory": "inner-build",
   "category": "Vascular Modeling Toolkit",
   "scm_revision": "master",
-  "scm_url": "https://github.com/vmtk/SlicerExtension-VMTK"
+  "scm_url": "https://github.com/vmtk/SlicerExtension-VMTK",
+  "tier": 5
 }

--- a/SlicerVirtualMouseCursor.json
+++ b/SlicerVirtualMouseCursor.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Utilities",
   "scm_revision": "main",
-  "scm_url": "https://github.com/KitwareMedical/SlicerVirtualMouseCursor"
+  "scm_url": "https://github.com/KitwareMedical/SlicerVirtualMouseCursor",
+  "tier": 3
 }

--- a/SlicerVirtualReality.json
+++ b/SlicerVirtualReality.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": "inner-build",
   "category": "Virtual Reality",
   "scm_revision": "master",
-  "scm_url": "https://github.com/KitwareMedical/SlicerVirtualReality.git"
+  "scm_url": "https://github.com/KitwareMedical/SlicerVirtualReality.git",
+  "tier": 5
 }

--- a/SlicerWMA.json
+++ b/SlicerWMA.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": "inner-build",
   "category": "Libraries",
   "scm_revision": "master",
-  "scm_url": "https://github.com/SlicerDMRI/SlicerWMA"
+  "scm_url": "https://github.com/SlicerDMRI/SlicerWMA",
+  "tier": 3
 }

--- a/SoundControl.json
+++ b/SoundControl.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "IGT",
   "scm_revision": "master",
-  "scm_url": "https://github.com/SlicerIGT/SlicerSoundControl"
+  "scm_url": "https://github.com/SlicerIGT/SlicerSoundControl",
+  "tier": 3
 }

--- a/Stereotaxia.json
+++ b/Stereotaxia.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "IGT",
   "scm_revision": "main",
-  "scm_url": "https://github.com/JBeninca/SlicerStereotaxia"
+  "scm_url": "https://github.com/JBeninca/SlicerStereotaxia",
+  "tier": 3
 }

--- a/SurfaceFragmentsRegistration.json
+++ b/SurfaceFragmentsRegistration.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Registration",
   "scm_revision": "master",
-  "scm_url": "https://github.com/sebastianandress/Slicer-SurfaceFragmentsRegistration.git"
+  "scm_url": "https://github.com/sebastianandress/Slicer-SurfaceFragmentsRegistration.git",
+  "tier": 3
 }

--- a/SurfaceLearner.json
+++ b/SurfaceLearner.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "SurfaceLearner",
   "scm_revision": "main",
-  "scm_url": "https://github.com/mturja-vf-ic-bd/SlicerSurfaceLearner"
+  "scm_url": "https://github.com/mturja-vf-ic-bd/SlicerSurfaceLearner",
+  "tier": 3
 }

--- a/SurfaceMarkup.json
+++ b/SurfaceMarkup.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Informatics",
   "scm_revision": "master",
-  "scm_url": "https://github.com/SlicerHeart/SlicerSurfaceMarkup.git"
+  "scm_url": "https://github.com/SlicerHeart/SlicerSurfaceMarkup.git",
+  "tier": 3
 }

--- a/SurfaceWrapSolidify.json
+++ b/SurfaceWrapSolidify.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Segmentation",
   "scm_revision": "master",
-  "scm_url": "https://github.com/sebastianandress/Slicer-SurfaceWrapSolidify.git"
+  "scm_url": "https://github.com/sebastianandress/Slicer-SurfaceWrapSolidify.git",
+  "tier": 5
 }

--- a/SwissSkullStripper.json
+++ b/SwissSkullStripper.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Segmentation",
   "scm_revision": "master",
-  "scm_url": "https://github.com/lassoan/SlicerSwissSkullStripper"
+  "scm_url": "https://github.com/lassoan/SlicerSwissSkullStripper",
+  "tier": 3
 }

--- a/T1Mapping.json
+++ b/T1Mapping.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Quantification",
   "scm_revision": "master",
-  "scm_url": "https://github.com/QIICR/T1Mapping.git"
+  "scm_url": "https://github.com/QIICR/T1Mapping.git",
+  "tier": 3
 }

--- a/T1_ECVMapping.json
+++ b/T1_ECVMapping.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Cardiac",
   "scm_revision": "master",
-  "scm_url": "https://github.com/RivettiLuciano/SlicerT1_ECVMapping.git"
+  "scm_url": "https://github.com/RivettiLuciano/SlicerT1_ECVMapping.git",
+  "tier": 3
 }

--- a/T2mapping.json
+++ b/T2mapping.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Quantification",
   "scm_revision": "master",
-  "scm_url": "https://github.com/gattia/Slicer-T2mapping"
+  "scm_url": "https://github.com/gattia/Slicer-T2mapping",
+  "tier": 3
 }

--- a/TCIABrowser.json
+++ b/TCIABrowser.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": ["QuantitativeReporting", "SlicerRT"],
   "build_subdirectory": ".",
   "category": "Informatics",
   "scm_revision": "master",
-  "scm_url": "https://github.com/QIICR/TCIABrowser.git"
+  "scm_url": "https://github.com/QIICR/TCIABrowser.git",
+  "tier": 3
 }

--- a/TITAN.json
+++ b/TITAN.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Analysis",
   "scm_revision": "master",
-  "scm_url": "https://github.com/SlicerMicro/Slicer-TITAN"
+  "scm_url": "https://github.com/SlicerMicro/Slicer-TITAN",
+  "tier": 3
 }

--- a/TOMAAT.json
+++ b/TOMAAT.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Segmentation",
   "scm_revision": "master",
-  "scm_url": "https://github.com/faustomilletari/TOMAAT-Slicer.git"
+  "scm_url": "https://github.com/faustomilletari/TOMAAT-Slicer.git",
+  "tier": 1
 }

--- a/TissueSegmentation.json
+++ b/TissueSegmentation.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Segmentation",
   "scm_revision": "main",
-  "scm_url": "https://github.com/MarinaSandonis/SlicerTissueSegmentation"
+  "scm_url": "https://github.com/MarinaSandonis/SlicerTissueSegmentation",
+  "tier": 1
 }

--- a/TomoSAM.json
+++ b/TomoSAM.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": ["PyTorch"],
   "build_subdirectory": ".",
   "category": "Segmentation",
   "scm_revision": "main",
-  "scm_url": "https://github.com/fsemerar/SlicerTomoSAM.git"
+  "scm_url": "https://github.com/fsemerar/SlicerTomoSAM.git",
+  "tier": 3
 }

--- a/TorchIO.json
+++ b/TorchIO.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": ["PyTorch"],
   "build_subdirectory": ".",
   "category": "Utilities",
   "scm_revision": "main",
-  "scm_url": "https://github.com/fepegar/SlicerTorchIO.git"
+  "scm_url": "https://github.com/fepegar/SlicerTorchIO.git",
+  "tier": 3
 }

--- a/TotalSegmentator.json
+++ b/TotalSegmentator.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": ["PyTorch"],
   "build_subdirectory": ".",
   "category": "Segmentation",
   "scm_revision": "main",
-  "scm_url": "https://github.com/lassoan/SlicerTotalSegmentator"
+  "scm_url": "https://github.com/lassoan/SlicerTotalSegmentator",
+  "tier": 5
 }

--- a/TrackingErrorInspector.json
+++ b/TrackingErrorInspector.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "IGT",
   "scm_revision": "master",
-  "scm_url": "https://github.com/SlicerIGT/SlicerTrackingErrorInspector"
+  "scm_url": "https://github.com/SlicerIGT/SlicerTrackingErrorInspector",
+  "tier": 3
 }

--- a/UHFMRTools.json
+++ b/UHFMRTools.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Filtering",
   "scm_revision": "trunk",
-  "scm_url": "https://github.com/harellab/SlicerUHFMRTools"
+  "scm_url": "https://github.com/harellab/SlicerUHFMRTools",
+  "tier": 3
 }

--- a/UKFTractography.json
+++ b/UKFTractography.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Tractography",
   "scm_revision": "master",
-  "scm_url": "https://github.com/pnlbwh/ukftractography.git"
+  "scm_url": "https://github.com/pnlbwh/ukftractography.git",
+  "tier": 5
 }

--- a/Ultrasound.json
+++ b/Ultrasound.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Ultrasound",
   "scm_revision": "main",
-  "scm_url": "https://github.com/SlicerUltrasound/SlicerUltrasound.git"
+  "scm_url": "https://github.com/SlicerUltrasound/SlicerUltrasound.git",
+  "tier": 3
 }

--- a/VASSTAlgorithms.json
+++ b/VASSTAlgorithms.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Registration",
   "scm_revision": "4.11",
-  "scm_url": "https://github.com/VASST/VASSTAlgorithms.git"
+  "scm_url": "https://github.com/VASST/VASSTAlgorithms.git",
+  "tier": 3
 }

--- a/VolumeClip.json
+++ b/VolumeClip.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Segmentation",
   "scm_revision": "master",
-  "scm_url": "https://github.com/PerkLab/SlicerVolumeClip.git"
+  "scm_url": "https://github.com/PerkLab/SlicerVolumeClip.git",
+  "tier": 3
 }

--- a/XNATSlicer.json
+++ b/XNATSlicer.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Remote",
   "scm_revision": "master",
-  "scm_url": "https://github.com/NrgXnat/XNATSlicer.git"
+  "scm_url": "https://github.com/NrgXnat/XNATSlicer.git",
+  "tier": 3
 }

--- a/ZFrameRegistration.json
+++ b/ZFrameRegistration.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": ["SlicerDevelopmentToolbox"],
   "build_subdirectory": ".",
   "category": "IGT",
   "scm_revision": "master",
-  "scm_url": "https://github.com/SlicerProstate/SlicerZFrameRegistration.git"
+  "scm_url": "https://github.com/SlicerProstate/SlicerZFrameRegistration.git",
+  "tier": 3
 }

--- a/flywheel_connect.json
+++ b/flywheel_connect.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Informatics",
   "scm_revision": "main",
-  "scm_url": "https://gitlab.com/flywheel-io/scientific-solutions/app/slicer_flywheel_connect.git"
+  "scm_url": "https://gitlab.com/flywheel-io/scientific-solutions/app/slicer_flywheel_connect.git",
+  "tier": 1
 }

--- a/mpReview.json
+++ b/mpReview.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [
     "SlicerDevelopmentToolbox",
     "QuantitativeReporting",
@@ -8,5 +8,6 @@
   "build_subdirectory": ".",
   "category": "Informatics",
   "scm_revision": "master",
-  "scm_url": "https://github.com/SlicerProstate/mpReview.git"
+  "scm_url": "https://github.com/SlicerProstate/mpReview.git",
+  "tier": 3
 }


### PR DESCRIPTION
By default, Tier 3 is assigned to all extensions - see list of exceptions (that assigned tier 1 or tier 5 instead) in the commit message.

Associated schema update: https://github.com/Slicer/Slicer/pull/8066

Required for https://github.com/Slicer/Slicer/issues/7474
