### PR TITLE
Fix SlicerSOFA packageupload error

### DIFF
--- a/SlicerSOFA.json
+++ b/SlicerSOFA.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
-  "build_subdirectory": ".",
+  "build_subdirectory": "inner-build",
   "category": "Simulation",
   "scm_revision": "main",
   "scm_url": "https://github.com/Slicer/SlicerSOFA",


### PR DESCRIPTION
In a superbuild extension, packageupload target is in the inner build folder.

fixes https://github.com/Slicer/SlicerSOFA/issues/31
