### PR TITLE
ENH: Add NNUNet extension as dependency for TotalSegmentator

### DIFF
--- a/TotalSegmentator.json
+++ b/TotalSegmentator.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
-  "build_dependencies": ["PyTorch"],
+  "build_dependencies": ["PyTorch", "NNUNet"],
   "build_subdirectory": ".",
   "category": "Segmentation",
   "scm_revision": "main",


### PR DESCRIPTION
This updates SlicerTotalSegmentator to specify SlicerNNUNet extension as a dependency. 

This new dependency is necessary as of https://github.com/lassoan/SlicerTotalSegmentator/pull/67.