### PR TITLE
Fix mismatch of Photogrammetry extensions json and extension name

### DIFF
--- a/Photogrammetry.json
+++ b/Photogrammetry.json
@@ -1,10 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/master/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": ["PyTorch", "SlicerMorph"],
   "build_subdirectory": ".",
   "category": "Photogrammetry",
   "scm_revision": "master",
   "scm_url": "https://github.com/SlicerMorph/SlicerPhotogrammetry.git",
-  "scm_type": "git",
   "tier": 1
 }


### PR DESCRIPTION
This fixes up accidental mistakes integrated through https://github.com/Slicer/ExtensionsIndex/pull/2139 where the json file was "SlicerPhotogrammetry" while the extension is "Photogrammetry" (per [here](https://github.com/SlicerMorph/SlicerPhotogrammetry/blob/6d65f18f7416e11a4e2e4acb9b44ece4256cf5f9/CMakeLists.txt#L2)).