### PR TITLE
ENH: point to a specified branch anticipating a markups JSON API change.

### DIFF
--- a/ExtraMarkups.json
+++ b/ExtraMarkups.json
@@ -3,7 +3,7 @@
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Utilities",
-  "scm_revision": "main",
+  "scm_revision": "5.8",
   "scm_url": "https://github.com/chir-set/SlicerExtraMarkups.git",
   "tier": 3
 }


### PR DESCRIPTION
See:
  https://github.com/chir-set/SlicerExtraMarkups/pull/9

Slicer [PR #8141](https://github.com/Slicer/Slicer/pull/8141) will introduce backwards incompatible changes.

Point the 5.8 stable branch of Slicer to the 'SlicerStable' branch of ExtraMarkups.
