### PR TITLE
ENH: Change SlicerMorph scm_revision for Stable

### DIFF
--- a/SlicerMorph.json
+++ b/SlicerMorph.json
@@ -3,7 +3,7 @@
   "build_dependencies": ["SegmentEditorExtraEffects", "SurfaceMarkup"],
   "build_subdirectory": ".",
   "category": "SlicerMorph",
-  "scm_revision": "master",
+  "scm_revision": "5.8",
   "scm_url": "https://github.com/SlicerMorph/SlicerMorph.git",
   "tier": 5
 }


### PR DESCRIPTION
Change SlicerMorph extension scm_revision to 5.8 for Stable Release.
