### PR TITLE
Update MorphoDepot.json - point to permanent home

### DIFF
--- a/MorphoDepot.json
+++ b/MorphoDepot.json
@@ -4,6 +4,6 @@
   "build_subdirectory": ".",
   "category": "SlicerMorph",
   "scm_revision": "main",
-  "scm_url": "https://github.com/pieper/SlicerMorphoDepot.git",
+  "scm_url": "https://github.com/MorphoCloud/SlicerMorphoDepot",
   "tier": 1
 }

--- a/MorphoDepot.json
+++ b/MorphoDepot.json
@@ -4,6 +4,6 @@
   "build_subdirectory": ".",
   "category": "SlicerMorph",
   "scm_revision": "main",
-  "scm_url": "https://github.com/MorphoCloud/SlicerMorphoDepot",
+  "scm_url": "https://github.com/MorphoCloud/SlicerMorphoDepot.git",
   "tier": 1
 }


### PR DESCRIPTION
The repo was transferred so github does the redirected correctly, but this is the new official repo.