### PR TITLE
Add LabelNameGenerator extension metadata

### DIFF
--- a/LabelNameGenerator.json
+++ b/LabelNameGenerator.json
@@ -1,0 +1,13 @@
+{
+  "extension_id": "LabelNameGenerator",
+  "name": "Label Name Generator",
+  "description": "A simple extension to create, save, and apply label groups for segmentation in 3D Slicer.",
+  "author": "Heo Eunseo (esheo-skia)",
+  "homepage": "https://github.com/esheo-skia/Slicer-LabelNameGenerator",
+  "category": "Segmentation",
+  "icon_url": "https://raw.githubusercontent.com/esheo-skia/Slicer-LabelNameGenerator/main/Resources/Icons/LabelNameGenerator.png",
+  "repository_type": "git",
+  "repository_url": "https://github.com/esheo-skia/Slicer-LabelNameGenerator.git",
+  "repository_branch": "main",
+  "license": "MIT"
+}


### PR DESCRIPTION
This pull request adds the metadata for a new 3D Slicer extension: `LabelNameGenerator`.

## Extension Overview
LabelNameGenerator is a simple extension that allows users to:
- Create and save custom label groups for segmentation.
- Apply random colors to each label.
- Easily load, reuse, and apply label groups via GUI.
- Automatically apply selected groups to Segment Editor.

Repository: https://github.com/esheo-skia/Slicer-LabelNameGenerator  
License: MIT  
Category: Segmentation

## Checklist for Tier 1 (✔️ Completed)
- [x] Repository follows naming convention: `Slicer-LabelNameGenerator`
- [x] Extension has license: MIT
- [x] README, icon, and basic documentation provided
- [x] Extension metadata file (.s4ext) is complete
- [x] `LabelNameGenerator.json` has been added
- [x] scmrevision uses `main` (not specific commit hash)
- [x] Public GitHub repository is available
- [x] Icon URL uses raw format and is accessible
- [x] Extension does not include or download binaries, and does not send data

Looking forward to review and feedback from the core team!
