### PR TITLE
ENH: freeze dcmqi version to v1.4.0 in 5.8

### DIFF
--- a/DCMQI.json
+++ b/DCMQI.json
@@ -3,7 +3,7 @@
   "build_dependencies": [],
   "build_subdirectory": "dcmqi-build",
   "category": "DICOM",
-  "scm_revision": "master",
+  "scm_revision": "v1.4.0",
   "scm_url": "https://github.com/QIICR/dcmqi.git",
   "tier": 5
 }


### PR DESCRIPTION
This is needed due to new developments in dcmqi that will require a more recent DCMTK 3.6.9, while Slicer is currently on 3.6.8.
