### PR TITLE
[5.8] ENH: Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v5.0.0
     hooks:
       - id: check-added-large-files
         args: ["--maxkb=1024"]
@@ -14,7 +14,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: "v3.1.0"
+    rev: "v4.0.0-alpha.8"
     hooks:
       - id: prettier
         types_or: [yaml, json]
@@ -26,7 +26,7 @@ repos:
       - id: remove-tabs
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: "0.28.0"
+    rev: "0.33.0"
     hooks:
       - id: check-jsonschema
         files: ^[^/]*\.json$


### PR DESCRIPTION
Backport from https://github.com/Slicer/ExtensionsIndex/pull/2180

---

- [pre-commit/pre-commit-hooks: v4.5.0 -> v5.0.0](https://github.com/pre-commit/pre-commit-hooks/compare/v4.5.0...v5.0.0)
- [pre-commit/mirrors-prettier: v3.1.0 -> v4.0.0](https://github.com/pre-commit/mirrors-prettier/compare/v3.1.0...v4.0.0)
- [python-jsonschema/check-jsonschema: 0.28.0 -> 0.33.0](https://github.com/python-jsonschema/check-jsonschema/compare/0.28.0...0.33.0)

---

This pull-request was generated running steps adapted from the [pre-commit-autoupdate][1] GitHub action workflow found in the Slicer project.

[1]: https://github.com/Slicer/Slicer/blob/main/.github/workflows/pre-commit-autoupdate.yml