### PR TITLE
ENH: Update pre-commit config to reference maintained "mirrors-prettier" hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,8 +13,8 @@ repos:
       - id: mixed-line-ending
       - id: trailing-whitespace
 
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: "v4.0.0-alpha.8"
+  - repo: https://github.com/rbubley/mirrors-prettier
+    rev: "v3.5.3"
     hooks:
       - id: prettier
         types_or: [yaml, json]


### PR DESCRIPTION
Use the fork of the (now archived) https://github.com/pre-commit/mirrors-prettier with the only difference being that it only references release versions of prettier, not e.g. alpha/beta versions.