### PR TITLE
Make SlicerFreeSurfer use 5.8 branch

### DIFF
--- a/SlicerFreeSurfer.json
+++ b/SlicerFreeSurfer.json
@@ -3,7 +3,7 @@
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Neuroimaging",
-  "scm_revision": "master",
+  "scm_revision": "5.8",
   "scm_url": "https://github.com/PerkLab/SlicerFreeSurfer.git",
   "tier": 5
 }


### PR DESCRIPTION
SlicerFreeSurfer master branch was updated to work with Slicer-5.9. SlicerFreeSurfer 5.8 branch is now needed for building with Slicer-5.8.

see https://github.com/Slicer/Slicer/issues/8490
