### PR TITLE
Update MorphoDepot.json - pin version

### DIFF
--- a/MorphoDepot.json
+++ b/MorphoDepot.json
@@ -5,7 +5,7 @@
   ],
   "build_subdirectory": ".",
   "category": "SlicerMorph",
-  "scm_revision": "main",
+  "scm_revision": "abbc16c76486b3723499ff45afaa47c5ac5717ed",
   "scm_url": "https://github.com/MorphoCloud/SlicerMorphoDepot.git",
   "tier": 1
 }


### PR DESCRIPTION
Allow testing and fixes to continue on main branch.

Since we are using the Slicer Preview releases in production due to the need for Terminology changes, we should treat this version as stable for now and not get untested changes into the published extension.

This is needed since I pushed a few commits to MorphoDepot main branch before realizing that if they have any issues they could disrupt current users.
