### PR TITLE
BUG: Workaround "check-jsonschema" caching issue by adding schema to repository

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,9 +34,10 @@ repos:
       - id: check-jsonschema
         files: ^[^/]*\.json$
         args:
+          # Using local schema file to avoid caching issues with remote URLs
           [
             "--schemafile",
-            "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json",
+            "schemas/slicer-extension-catalog-entry-schema-v1.0.1.json",
           ]
       - id: check-dependabot
       - id: check-github-workflows

--- a/schemas/slicer-extension-catalog-entry-schema-v1.0.1.json
+++ b/schemas/slicer-extension-catalog-entry-schema-v1.0.1.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
+  "type": "object",
+  "title": "3D Slicer extensions catalog entry schema",
+  "description": "Schema for storing information about a 3D Slicer extension to allow it to be listed in the extension catalog.",
+  "required": [
+    "$schema",
+    "category",
+    "scm_url"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "$schema": {
+      "$id": "#schema",
+      "type": "string",
+      "title": "Schema",
+      "description": "URL of versioned schema."
+    },
+    "category": {
+      "$id": "#category",
+      "type": "string",
+      "title": "Category used to organize the extension in the extension catalog."
+    },
+    "scm_url": {
+      "$id": "#scm_url",
+      "type": "string",
+      "title": "Filename or URL of the repository."
+    },
+    "scm_revision": {
+      "$id": "#scm_revision",
+      "type": "string",
+      "title": "Hash, branch or tag name to identify the revision within the repository."
+    },
+    "scm_type": {
+      "$id": "#scm_type",
+      "type": "string",
+      "title": "Type of revision control system.",
+      "enum": [
+        "git",
+        "local"
+      ],
+      "default": "git"
+    },
+    "build_dependencies": {
+      "$id": "#build_dependencies",
+      "type": "array",
+      "title": "List of extensions required to build this extension.",
+      "additionalItems": false,
+      "items": { "type": "string" }
+    },
+    "build_subdirectory": {
+      "$id": "#build_subdirectory",
+      "type": "string",
+      "title": "Name of the inner build directory in case of superbuild based extension.",
+      "default": "."
+    },
+    "enabled": {
+      "$id": "#enabled",
+      "type": "boolean",
+      "title": "Specify if the extension should be enabled after its installation.",
+      "default": true
+    },
+    "tier": {
+      "$id": "#tier",
+      "type": "integer",
+      "title": "Maturity and support level of the extension. Higher is better. 1 means experimental, 3 means supported by community, 5 means supported by Slicer core developers.",
+      "default": 1,
+      "minimum": 1,
+      "maximum": 5
+    }
+  }
+}


### PR DESCRIPTION
This commit addresses errors reported during the GitHub workflow associated with `.github/workflows/lint.yml`:

```
Error: schemafile could not be parsed as JSON
SchemaParseError: https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json
  in "/home/runner/.cache/pre-commit/reporsapdpi1/py_env-python3.9/lib/python3.9/site-packages/check_jsonschema/checker.py", line 56
  >>> return self._schema_loader.get_validator(

  caused by

  FailedFileLoadError: Failed to parse https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json
    in "/home/runner/.cache/pre-commit/reporsapdpi1/py_env-python3.9/lib/python3.9/site-packages/check_jsonschema/schema_loader/readers.py", line 27
    >>> schema = callback()
```