### PR TITLE
Fix running of ai analysis on forks

### DIFF
--- a/.github/workflows/extension-ai-analysis.yml
+++ b/.github/workflows/extension-ai-analysis.yml
@@ -11,7 +11,6 @@ concurrency:
 jobs:
   ai-analysis:
     runs-on: ubuntu-latest
-    environment: ai-analysis # 👈 requires approval from slicer-developer to avoid exposing secret (API key)
     permissions:
       contents: read
       pull-requests: write

--- a/scripts/extension_ai_analysis.py
+++ b/scripts/extension_ai_analysis.py
@@ -19,7 +19,7 @@ import shutil
 # It offers capable models for free with an OpenAI-compatible API.
 INFERENCE_URL = "https://inference.nebulablock.com/v1/chat/completions"
 INFERENCE_MODEL = "mistralai/Mistral-Small-3.2-24B-Instruct-2506"
-INFERENCE_RESPONSE_PER_MINUTE_LIMIT = 3
+INFERENCE_RESPONSE_PER_MINUTE_LIMIT = 5
 INFERENCE_API_KEY = os.getenv("NEBULA_API_KEY")
 
 QUESTIONS = [


### PR DESCRIPTION
No need to use a special environment for a free API key. Allow completing AI analysis in 2 minutes by increasing response per minute limit.
