### PR TITLE
Fix extension-ai-analysis action concurrency

### DIFF
--- a/.github/workflows/extension-ai-analysis.yml
+++ b/.github/workflows/extension-ai-analysis.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Only one action was allowed per repository, instead of one per pull request.
