### PR TITLE
Removed Telemetry dependency from BoneReconstructionPlanner

### DIFF
--- a/BoneReconstructionPlanner.json
+++ b/BoneReconstructionPlanner.json
@@ -1,11 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
-  "build_dependencies": [
-    "SurfaceWrapSolidify",
-    "MarkupsToModel",
-    "Sandbox",
-    "Telemetry"
-  ],
+  "build_dependencies": ["SurfaceWrapSolidify", "MarkupsToModel", "Sandbox"],
   "build_subdirectory": ".",
   "category": "Planning",
   "scm_revision": "main",


### PR DESCRIPTION
Slicer build fails due to Telemetry extension is not in the ExtensionsIndex but required by BoneReconstructionPlanner. Since Slicer-5.8 builds (and therefore extension updates) will stop within in a week it is better to not add the Telemetry extension now (which is still not widely tested and so may not be very mature). It is not a build-time dependency anyway and its installation is optional for the user.

FYI @mauigna06 