### PR TITLE
BUG: Fix extension index build updating LayerDisplayableManager build_subdirectory

### DIFF
--- a/LayerDisplayableManager.json
+++ b/LayerDisplayableManager.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
-  "build_subdirectory": "",
+  "build_subdirectory": ".",
   "category": "Developer Tools",
   "scm_revision": "main",
   "scm_url": "https://github.com/KitwareMedical/SlicerLayerDisplayableManager",


### PR DESCRIPTION
This fixes the following error reported when attempting to build the extensions index:

```
-- Configuring extension: LayerDisplayableManager
CMake Error at SlicerBlockUploadExtension.cmake:23 (message):
  Variable EXTENSION_BUILD_SUBDIRECTORY is not defined !
Call Stack (most recent call first):
  SlicerBlockBuildPackageAndUploadExtensions.cmake:187 (include)
  CMakeLists.txt:63 (include)
```