### PR TITLE
Switch MONAIAuto3DSeg to use 5.8 branch

### DIFF
--- a/MONAIAuto3DSeg.json
+++ b/MONAIAuto3DSeg.json
@@ -3,7 +3,7 @@
   "build_dependencies": ["PyTorch"],
   "build_subdirectory": ".",
   "category": "Segmentation",
-  "scm_revision": "main",
+  "scm_revision": "5.8",
   "scm_url": "https://github.com/lassoan/SlicerMONAIAuto3DSeg",
   "tier": 5
 }


### PR DESCRIPTION
This allows making backward-incompatible changes in the main branch.
