### PR TITLE
BUG: downgrade QuantitativeReporting

### DIFF
--- a/QuantitativeReporting.json
+++ b/QuantitativeReporting.json
@@ -7,7 +7,7 @@
   ],
   "build_subdirectory": ".",
   "category": "Informatics",
-  "scm_revision": "master",
+  "scm_revision": "2c0112785c9ba3af9be6a1f86d5ed7bb8b700705",
   "scm_url": "https://github.com/QIICR/QuantitativeReporting.git",
   "tier": 5
 }


### PR DESCRIPTION
The latest update requires pydicom v3, while currently Slicer is using 2.4.4, and it is not trivial to upgrade.

See discussion in https://github.com/QIICR/QuantitativeReporting/issues/293#issuecomment-3413153744 and related issue https://github.com/Slicer/Slicer/issues/8796.