### PR TITLE
ENH: Add DICOM support rule to extension metadata

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
           # Using local schema file to avoid caching issues with remote URLs
           [
             "--schemafile",
-            "schemas/slicer-extension-catalog-entry-schema-v1.0.1.json",
+            "schemas/slicer-extension-catalog-entry-schema-v1.0.2.json",
           ]
       - id: check-dependabot
       - id: check-github-workflows

--- a/PETDICOMExtension.json
+++ b/PETDICOMExtension.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.2.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Converters",
+  "dicom_support_rule": "Modality == 'PT' or Modality == 'RWVM'",
   "scm_revision": "master",
   "scm_url": "https://github.com/QIICR/Slicer-PETDICOMExtension.git",
   "tier": 3

--- a/QuantitativeReporting.json
+++ b/QuantitativeReporting.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.2.json#",
   "build_dependencies": [
     "SlicerDevelopmentToolbox",
     "DCMQI",
@@ -9,5 +9,6 @@
   "category": "Informatics",
   "scm_revision": "master",
   "scm_url": "https://github.com/QIICR/QuantitativeReporting.git",
-  "tier": 5
+  "tier": 5,
+  "dicom_support_rule": "(Modality == 'SEG') or (SOPClassUID == '1.2.840.10008.5.1.4.1.1.30') or (Modality == 'SR' and (SOPClassUID == '1.2.840.10008.5.1.4.1.1.88.22' or SOPClassUID == '1.2.840.10008.5.1.4.1.1.88.33'))"
 }

--- a/QuantitativeReporting.json
+++ b/QuantitativeReporting.json
@@ -10,5 +10,5 @@
   "scm_revision": "master",
   "scm_url": "https://github.com/QIICR/QuantitativeReporting.git",
   "tier": 5,
-  "dicom_support_rule": "(Modality == 'SEG') or (SOPClassUID == '1.2.840.10008.5.1.4.1.1.30') or (Modality == 'SR' and (SOPClassUID == '1.2.840.10008.5.1.4.1.1.88.22' or SOPClassUID == '1.2.840.10008.5.1.4.1.1.88.33'))"
+  "dicom_support_rule": "(Modality == 'SEG') or (SOPClassUID == '1.2.840.10008.5.1.4.1.1.30') or (Modality == 'SR' and (SOPClassUID == '1.2.840.10008.5.1.4.1.1.88.22' or SOPClassUID == '1.2.840.10008.5.1.4.1.1.88.33' or SOPClassUID == '1.2.840.10008.5.1.4.1.1.88.34')) or (Modality == 'M3D')"
 }

--- a/SlicerDMRI.json
+++ b/SlicerDMRI.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.2.json#",
   "build_dependencies": [
     "UKFTractography"
   ],
@@ -7,5 +7,6 @@
   "category": "Diffusion",
   "scm_revision": "master",
   "scm_url": "https://github.com/SlicerDMRI/SlicerDMRI.git",
-  "tier": 5
+  "tier": 5,
+  "dicom_support_rule": "Modality == 'MR'"
 }

--- a/SlicerHeart.json
+++ b/SlicerHeart.json
@@ -5,7 +5,7 @@
   ],
   "build_subdirectory": "inner-build",
   "category": "Cardiac",
-  "dicom_support_rule": "SOPClassUID == '1.2.840.113543.6.6.1.3.10002'",
+  "dicom_support_rule": "SOPClassUID == '1.2.840.113543.6.6.1.3.10002' or SOPClassUID == '1.2.840.10008.5.1.4.1.1.3.1' or SOPClassUID == '1.2.840.10008.5.1.4.1.1.6.1'",
   "scm_revision": "master",
   "scm_url": "https://github.com/SlicerHeart/SlicerHeart.git",
   "tier": 5

--- a/SlicerHeart.json
+++ b/SlicerHeart.json
@@ -1,10 +1,11 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.2.json#",
   "build_dependencies": [
     "SlicerIGT"
   ],
   "build_subdirectory": "inner-build",
   "category": "Cardiac",
+  "dicom_support_rule": "SOPClassUID == '1.2.840.113543.6.6.1.3.10002'",
   "scm_revision": "master",
   "scm_url": "https://github.com/SlicerHeart/SlicerHeart.git",
   "tier": 5

--- a/SlicerRT.json
+++ b/SlicerRT.json
@@ -1,9 +1,10 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.2.json#",
   "build_dependencies": [],
   "build_subdirectory": "inner-build",
   "category": "Radiotherapy",
   "scm_revision": "master",
   "scm_url": "https://github.com/SlicerRt/SlicerRT.git",
-  "tier": 5
+  "tier": 5,
+  "dicom_support_rule": "Modality == 'RTDOSE' or Modality == 'RTSTRUCT' or Modality == 'RTPLAN' or Modality == 'RTIMAGE' or SOPClassUID == '1.2.840.10008.5.1.4.1.1.66.1' or SOPClassUID == '1.2.840.10008.5.1.4.1.1.66.2' or SOPClassUID == '1.2.840.10008.5.1.4.1.1.66.3'"
 }

--- a/SlicerRT.json
+++ b/SlicerRT.json
@@ -6,5 +6,5 @@
   "scm_revision": "master",
   "scm_url": "https://github.com/SlicerRt/SlicerRT.git",
   "tier": 5,
-  "dicom_support_rule": "Modality == 'RTDOSE' or Modality == 'RTSTRUCT' or Modality == 'RTPLAN' or Modality == 'RTIMAGE' or SOPClassUID == '1.2.840.10008.5.1.4.1.1.66.1' or SOPClassUID == '1.2.840.10008.5.1.4.1.1.66.2' or SOPClassUID == '1.2.840.10008.5.1.4.1.1.66.3'"
+  "dicom_support_rule": "Modality == 'RTDOSE' or Modality == 'RTSTRUCT' or Modality == 'RTPLAN' or Modality == 'RTIMAGE' or Modality == 'REG' or SOPClassUID == '1.2.840.10008.5.1.4.1.1.66.1' or SOPClassUID == '1.2.840.10008.5.1.4.1.1.66.2' or SOPClassUID == '1.2.840.10008.5.1.4.1.1.66.3'"
 }

--- a/schemas/slicer-extension-catalog-entry-schema-v1.0.2.json
+++ b/schemas/slicer-extension-catalog-entry-schema-v1.0.2.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.2.json#",
+  "type": "object",
+  "title": "3D Slicer extensions catalog entry schema",
+  "description": "Schema for storing information about a 3D Slicer extension to allow it to be listed in the extension catalog.",
+  "required": [
+    "$schema",
+    "category",
+    "scm_url"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "$schema": {
+      "$id": "#schema",
+      "type": "string",
+      "title": "Schema",
+      "description": "URL of versioned schema."
+    },
+    "category": {
+      "$id": "#category",
+      "type": "string",
+      "title": "Category used to organize the extension in the extension catalog."
+    },
+    "scm_url": {
+      "$id": "#scm_url",
+      "type": "string",
+      "title": "Filename or URL of the repository."
+    },
+    "scm_revision": {
+      "$id": "#scm_revision",
+      "type": "string",
+      "title": "Hash, branch or tag name to identify the revision within the repository."
+    },
+    "scm_type": {
+      "$id": "#scm_type",
+      "type": "string",
+      "title": "Type of revision control system.",
+      "enum": [
+        "git",
+        "local"
+      ],
+      "default": "git"
+    },
+    "build_dependencies": {
+      "$id": "#build_dependencies",
+      "type": "array",
+      "title": "List of extensions required to build this extension.",
+      "additionalItems": false,
+      "items": { "type": "string" }
+    },
+    "dicom_support_rule": {
+      "$id": "#dicom_support_rule",
+      "type": "string",
+      "title": "Rule engine expression to determine DICOM support level of the extension. (https://pypi.org/project/rule-engine/)"
+    },
+    "build_subdirectory": {
+      "$id": "#build_subdirectory",
+      "type": "string",
+      "title": "Name of the inner build directory in case of superbuild based extension.",
+      "default": "."
+    },
+    "enabled": {
+      "$id": "#enabled",
+      "type": "boolean",
+      "title": "Specify if the extension should be enabled after its installation.",
+      "default": true
+    },
+    "tier": {
+      "$id": "#tier",
+      "type": "integer",
+      "title": "Maturity and support level of the extension. Higher is better. 1 means experimental, 3 means supported by community, 5 means supported by Slicer core developers.",
+      "default": 1,
+      "minimum": 1,
+      "maximum": 5
+    }
+  }
+}

--- a/scripts/check_description_files.py
+++ b/scripts/check_description_files.py
@@ -575,9 +575,12 @@ def main():
         if file_extension != '.json':
             # not an extension description file, ignore it
             continue
+        if os.path.dirname(file_path) not in ('', '.'):
+            # not a file in the extensions descriptions folder, ignore it
+            continue
         full_path = os.path.join(extension_descriptions_folder, file_path)
         if not os.path.isfile(full_path):
-            # not a file in the extensions descriptions folder, ignore it
+            # file does not exist, ignore it
             continue
         extension_name = os.path.splitext(os.path.basename(file_path))[0]
         found_extensions.append(extension_name)


### PR DESCRIPTION
Add dicom_support_rule field to extension catalog entries to enable DICOM-aware extension filtering and automatic extension activation.

Schema changes:
* Add dicom_support_rule field to extension catalog schema v1.0.1
* Field contains rule engine expression for DICOM data matching
* Uses Python rule-engine syntax for flexible DICOM tag comparisons

Extension updates with DICOM support rules:
* PETDICOMExtension: PT and RWVM modality support
* QuantitativeReporting: SEG, parametric maps, and SR support
* SlicerHeart: Cardiac ultrasound (Philips DICOM private format)
* SlicerRT: Radiotherapy modalities (RTDOSE, RTSTRUCT, RTPLAN, RTIMAGE)

This enables Slicer to automatically suggest or activate relevant extensions when opening DICOM data matching the specified rules.