### PR TITLE
ENH: Add PyTorch dependency to SlicerDMRI

### DIFF
--- a/SlicerDMRI.json
+++ b/SlicerDMRI.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.2.json#",
   "build_dependencies": [
-    "UKFTractography"
+    "UKFTractography",
+    "PyTorch"
   ],
   "build_subdirectory": "inner-build",
   "category": "Diffusion",


### PR DESCRIPTION
The TractCloud module in SlicerDMRI now uses PyTorch for deep learning-based tractography parcellation. Adding PyTorch as a build dependency ensures the PyTorchUtils extension is installed for correct CUDA/CPU wheel selection.

Related PRs:
- SlicerDMRI/TractCloud#1 (inference CLI package)
- SlicerDMRI/SlicerDMRI#252 (TractCloud module refactor, merged)
- SlicerDMRI/SlicerDMRI#255 (review feedback: use PyTorchUtils)

Per @jamesobutler's review feedback on SlicerDMRI/SlicerDMRI#252.