### PR TITLE
Add SEEGContactDetector to 5.10 index

### DIFF
--- a/SEEGContactDetector.json
+++ b/SEEGContactDetector.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
+  "category": "IGT",
+  "tier": 3,
+  "scm_url": "https://github.com/EpiReC-ISARG/SlicerSEEGContactDetector",
+  "scm_type": "git",
+  "scm_revision": "5.10",
+  "build_dependencies": [
+    "HDBrainExtraction"
+  ],
+  "build_subdirectory": "."
+}


### PR DESCRIPTION
## Extension backport to Slicer 5.10

This PR adds the SEEGContactDetector extension to the Slicer 5.10 stable release index. 

This is a backport of the work done in PR #2293 , which has been reviewed and targeted for the `main` branch.