### PR TITLE
MorphoDepot: update scm_url after repo transfer to SlicerMorph

### DIFF
--- a/MorphoDepot.json
+++ b/MorphoDepot.json
@@ -6,6 +6,6 @@
   "build_subdirectory": ".",
   "category": "SlicerMorph",
   "scm_revision": "main",
-  "scm_url": "https://github.com/MorphoCloud/SlicerMorphoDepot.git",
+  "scm_url": "https://github.com/SlicerMorph/SlicerMorphoDepot.git",
   "tier": 1
 }


### PR DESCRIPTION
The `MorphoDepot` extension repository was transferred from `MorphoCloud/SlicerMorphoDepot` to `SlicerMorph/SlicerMorphoDepot` a few weeks ago. This updates `scm_url` in `MorphoDepot.json` to the new address.

`scm_revision` is unchanged (`main`, which exists on the new repo). The old URL still redirects, so this is a correctness/clarity update.

cc the SlicerMorph maintainers.