### PR TITLE
Update Bone Imaging Toolbox extension entry

### DIFF
--- a/BoneImagingToolbox.json
+++ b/BoneImagingToolbox.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.2.json#",
+  "build_dependencies": [],
+  "build_subdirectory": ".",
+  "category": "Quantification",
+  "enabled": true,
+  "scm_revision": "main",
+  "scm_type": "git",
+  "scm_url": "https://github.com/wallematthias/SlicerBoneImagingToolbox",
+  "tier": 1
+}

--- a/TimelapsedHRpQCTSlicer.json
+++ b/TimelapsedHRpQCTSlicer.json
@@ -1,9 +1,0 @@
-{
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
-  "build_dependencies": [],
-  "build_subdirectory": ".",
-  "category": "Quantification",
-  "scm_revision": "main",
-  "scm_url": "https://github.com/wallematthias/SlicerTimelapsedHRpQCT",
-  "tier": 1
-}


### PR DESCRIPTION
## Summary
- Rename the existing `TimelapsedHRpQCTSlicer` catalog entry to `BoneImagingToolbox`
- Point the ExtensionIndex entry at https://github.com/wallematthias/SlicerBoneImagingToolbox
- Update the entry to the current catalog schema style with explicit git SCM type and enabled flag

## Context
This is the follow-up to prior reviewer guidance in https://github.com/Slicer/ExtensionsIndex/pull/2332#issuecomment-4302459120, where grouping HR-pQCT modules into one already-approved extension was recommended instead of submitting separate extensions for each module.

The toolbox repository now acts as that single extension container. It includes Timelapsed HR-pQCT, Motion Score HR-pQCT, Scanco I/O, Segmentation HR-pQCT, and space for future bone-imaging modules under one ExtensionIndex entry.
