### PR TITLE
Fix DRAISegmentation build configuration

### DIFF
--- a/DRAISegmentation.json
+++ b/DRAISegmentation.json
@@ -1,9 +1,8 @@
 {
   "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "build_dependencies": [],
-  "build_subdirectory": "inner-build",
   "category": "Segmentation",
-  "scm_revision": "ff07f81a47c8794c767137e0397d90900e2688a8",
+  "scm_revision": "984c135c83f84c2a52a0a840c49b2567b1a5f6e5",
   "scm_url": "https://github.com/DeepReasoningAI/SlicerDRAISegmentation.git",
   "tier": 1
 }


### PR DESCRIPTION
Updates the existing DRAISegmentation extension entry to use the corrected build configuration and source revision.

- Removes the obsolete `build_subdirectory: inner-build` setting.
- Updates `scm_revision` to [DeepReasoningAI/SlicerDRAISegmentation@984c135](https://github.com/DeepReasoningAI/SlicerDRAISegmentation/commit/984c135c83f84c2a52a0a840c49b2567b1a5f6e5).
- The source update removes unintended superbuild settings and the duplicate `find_package(Slicer)` call that caused the extension build failure.

The corrected extension was packaged successfully locally for Slicer 5.12.3 on Windows x64.